### PR TITLE
Resolves and queues active jobs conventionally based on class name

### DIFF
--- a/app/assets/javascripts/board/application.js
+++ b/app/assets/javascripts/board/application.js
@@ -2803,12 +2803,6 @@ var Repo = Ember.Object.extend(Serializable,{
   repoUrl :function () {
     return this.get("userUrl") + "/" + this.get("name");
   }.property("name", "userUrl"),
-  backlogUrl: function () {
-     return this.get("repoUrl") + "/backlog";
-  }.property("repoUrl"),
-  betaUrl: function () {
-     return this.get("repoUrl") + "/beta";
-  }.property("repoUrl"),
   fetchBoard: function(linkedBoards){
     if(this._board) {return this._board;}
     return Ember.$.getJSON("/api/" + this.get("full_name") + "/board").then(function(board){
@@ -3381,7 +3375,7 @@ function program9(depth0,data) {
   hashContexts = {'href': depth0};
   hashTypes = {'href': "STRING"};
   data.buffer.push(escapeExpression(helpers['bind-attr'].call(depth0, {hash:{
-    'href': ("betaUrl")
+    'href': ("repoUrl")
   },contexts:[],types:[],hashContexts:hashContexts,hashTypes:hashTypes,data:data})));
   data.buffer.push(">");
   hashTypes = {};

--- a/app/assets/javascripts/board/models/repo.js
+++ b/app/assets/javascripts/board/models/repo.js
@@ -9,12 +9,6 @@ var Repo = Ember.Object.extend(Serializable,{
   repoUrl :function () {
     return this.get("userUrl") + "/" + this.get("name");
   }.property("name", "userUrl"),
-  backlogUrl: function () {
-     return this.get("repoUrl") + "/backlog";
-  }.property("repoUrl"),
-  betaUrl: function () {
-     return this.get("repoUrl") + "/beta";
-  }.property("repoUrl"),
   fetchBoard: function(linkedBoards){
     if(this._board) {return this._board;}
     return Ember.$.getJSON("/api/" + this.get("full_name") + "/board").then(function(board){

--- a/app/assets/javascripts/board/templates/application.hbs
+++ b/app/assets/javascripts/board/templates/application.hbs
@@ -4,7 +4,7 @@
     <ul class="nav breadcrumbs">
       <li><a href="/" class="home"><i class="ui-icon ui-icon-menu"></i></a></li>
       <li><a {{bind-attr href="userUrl"}} >{{model.owner.login}}</a></li>
-      <li><a {{bind-attr href="betaUrl"}}>{{model.name}}</a></li>
+      <li><a {{bind-attr href="repoUrl"}}>{{model.name}}</a></li>
       <li>
          {{render "search"}} 
       </li>

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -15,15 +15,15 @@ class ErrorsController < ApplicationController
   def unprocessable_entity
     @exception = env["action_dispatch.exception"]
     respond_to do |format|
-      format.html {render :server_error, status: 422 }
-      format.json { render json: { status: 422, error: @exception.message }}
+      format.html { render :server_error, status: 422 }
+      format.json { render json: { status: 422, error: @exception.message, message: @exception.message}, status: 422  }
     end
   end
   def server_error
     @exception = env["action_dispatch.exception"]
     respond_to do |format|
       format.html {render :server_error, status: 500 }
-      format.json { render json: { status: 500, error: @exception.message }}
+      format.json { render json: { status: 500, error: @exception.message, message: @exception.message}, status: 500  }
     end
   end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -21,7 +21,7 @@
         <% end %>
         <% @repos.each do |repo| %>
           <li class="repo">
-        <a href="<%= "/#{repo["owner"]["login"]}/#{repo["name"]}/backlog" %>"><span>backlog</span></a> 
+        <a href="<%= "/#{repo["owner"]["login"]}/#{repo["name"]}/#/milestones" %>"><span>backlog</span></a> 
         <a class="board" href="<%= "/#{repo["owner"]["login"]}/#{repo["name"]}" %>"><span>open issues</span><strong><%=repo["open_issues"]%></strong></a> 
         <span>
           <% if repo['private'] %>


### PR DESCRIPTION
Proof of concept for conventional active job queuing

The JobResolver will first look for a job based on controller_action and then fallback to controller 

example

```
class FooController < ApplicationController
    def create
      @foo = Foo.create params
    end
end
```
would conventionally queue a `FooCreateJob`

```
#=> app/jobs/foo_create_job.rb
class FooCreateJob < ActiveJob::Base
    def perform(params)
        params[:foo] #=> the foo record
    end
end
```

:boom: :tada: :sparkles: :sparkles: 