### PR TITLE
Disable the deep munging in rails to allow empty arrays in params payloads

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -58,5 +58,4 @@ module HuboardWeb
     # Ricki Mar 17 2015
     config.action_dispatch.perform_deep_munge = false
   end
-
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -53,5 +53,10 @@ module HuboardWeb
     config.exceptions_app = self.routes
 
     config.active_job.queue_adapter = :sucker_punch
+    # !!! This addresses a Rails Behaviour that coaxes empty arrays in the params hash into nils 
+    # see https://github.com/rails/rails/pull/13188
+    # Ricki Mar 17 2015
+    config.action_dispatch.perform_deep_munge = false
   end
+
 end


### PR DESCRIPTION
See https://github.com/rails/rails/pull/13188/files

This is the line that was killing some our request payloads:
https://github.com/rails/rails/blob/e8572cf2f94872d81e7145da31d55c6e1b074247/actionpack/lib/action_dispatch/request/utils.rb#L18

<!---
@huboard:{"order":4.125,"milestone_order":13,"custom_state":"ready"}
-->
