### PR TITLE
Disables event jobs from generating for issue actions already handled

### DIFF
--- a/app/controllers/api/issues_controller.rb
+++ b/app/controllers/api/issues_controller.rb
@@ -7,8 +7,8 @@ module Api
     end
 
     def create_issue
-      @issue = huboard.board(params[:user],params[:repo]).create_issue params
-      render json: @issue
+      issue = huboard.board(params[:user],params[:repo]).create_issue params
+      render json: issue
     end
 
     def update_issue
@@ -19,14 +19,14 @@ module Api
 
     def close_issue
       user, repo, number = params[:user], params[:repo], params[:number]
-      @issue = huboard.board(user, repo).issue(number).close
-      render json: @issue
+      issue = huboard.board(user, repo).issue(number).close
+      render json: issue
     end
 
     def reopen_issue
       user, repo, number = params[:user], params[:repo], params[:number]
-      @issue = huboard.board(user, repo).issue(number).open
-      render json: @issue
+      issue = huboard.board(user, repo).issue(number).open
+      render json: issue
     end
 
     #TODO original api checks if comment['message'] exists


### PR DESCRIPTION
We are doubling up on:
  - issue open
  - issue reopen
  - issue closed 

Because webhooks are also generating events based on HuBoards api calls, I have disabled these routes from automatically generating event jobs. 

Am I perceiving this problem too simply @rauhryan ?