### PR TITLE
Lowercases all subscribers on the socket

### DIFF
--- a/ember-app/app/app.js
+++ b/ember-app/app/app.js
@@ -54,6 +54,7 @@ Ember.onLoad("Ember.Application", function ($app) {
             this.get("sockets")[channel].callbacks.remove(callback);
           },
           subscribeTo: function(channel) {
+            channel = channel.toLowerCase();
             var client = this.get('client'), 
             callbacks = Ember.$.Callbacks();
             client.disable("eventsource");

--- a/ember-app/app/app.js
+++ b/ember-app/app/app.js
@@ -47,10 +47,12 @@ Ember.onLoad("Ember.Application", function ($app) {
           sockets: {},
           client: new Faye.Client(application.get('socketBackend')),
           subscribe: function (channel, callback) {
+            channel = channel.toLowerCase();
             this.get("sockets")[channel].callbacks.add(callback);
             return callback;
           },
           unsubscribe: function(channel, callback) {
+            channel = channel.toLowerCase();
             this.get("sockets")[channel].callbacks.remove(callback);
           },
           subscribeTo: function(channel) {


### PR DESCRIPTION
When the socket fails the runloop also fails to execute all currently scheduled events - which in this case caused columns not to register to the parent controller, in turn causing crazy bugs.