### PR TITLE
Specifies version for vagrant box to use puppet 3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,7 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = "puppetlabs/ubuntu-14.04-64-puppet"
+  config.vm.box_version = "= 1.0.1"
 
   config.vm.synced_folder ".", "/srv/huboard", type: "nfs"
   config.vm.network "private_network", ip: "192.168.50.10"


### PR DESCRIPTION
I ran into problems following the [Local Development](https://github.com/rauhryan/huboard/wiki/Local-Development) instructions. Seems to be due to being fresh and getting gems and vagrant boxes with puppet 4. The change to use environments requires some changes to the Vagrantfile, [this](https://github.com/mitchellh/vagrant/issues/3740) helped. But once, I thought I was around that I ran into other issues so this seemed like the best path to get it up and running and thought it made sense to version the box and update the wiki until someone can further investigate updating things to work with puppet 4.

In addition to the change made by this PR, I would update the wiki with these changes:

```rvm use 2.1.5```
```gem install puppet -v "<4"```