### PR TITLE
Fixed word wrap problem inside comment boxes

### DIFF
--- a/app/assets/stylesheets/_overlay.scss
+++ b/app/assets/stylesheets/_overlay.scss
@@ -237,6 +237,17 @@ body > .fullscreen-overlay {
       display:none;
     }
   }
+  .comment-text {
+      -ms-word-break: break-all;
+      word-break: break-all;
+
+      // Non standard for webkit
+      word-break: break-word;
+
+      -webkit-hyphens: auto;
+      -moz-hyphens: auto;
+      hyphens: auto;
+    }
 
 }
 

--- a/ember-app/app/components/hb-task-list.js
+++ b/ember-app/app/components/hb-task-list.js
@@ -3,7 +3,7 @@ import config from '../config/environment'; //jshint ignore:line
 import MarkdownParsing from '../mixins/markdown-parsing';
 
 var HbTaskListComponent = Ember.Component.extend(MarkdownParsing, {
-  classNames: ["js-task-list-container"],
+  classNames: ["js-task-list-container", "comment-text"],
   onBodyChange: function(){
     Ember.run(this, function(){
       this.set("bodyMarkup", this.get('body_html'));


### PR DESCRIPTION
As you can see below, the comments on issues were not being word-wrapped, but descriptions are.  I added a class to the comments and just used the same word-break styling that was already being used for descriptions.

![screen shot 2015-10-24 at 10 46 17 pm](https://cloud.githubusercontent.com/assets/2813592/10718069/4c00cbb8-7b40-11e5-89ff-8215245ede01.png)
