### PR TITLE
Adds sorting to assignees, milestones, and label flyouts.

### DIFF
--- a/ember-app/app/components/hb-assignee.js
+++ b/ember-app/app/components/hb-assignee.js
@@ -12,6 +12,7 @@ var HbAssigneeComponent = Ember.Component.extend({
 
   listItems: function () {
 
+    var currentUserLogin = this.get("currentUser").login;
     return this.get("assignees")
     .filter(function(item) {
       var term = this.get("filterPeople") || "";
@@ -20,6 +21,7 @@ var HbAssigneeComponent = Ember.Component.extend({
     .map(function(item) {
 
       return this.ListItem.create({
+        currentUser: item.login === currentUserLogin,
         selected: item.id === this.get("selected.id"),
         item: item
       });
@@ -29,9 +31,13 @@ var HbAssigneeComponent = Ember.Component.extend({
   }.property("assignees.[]","selected","filterPeople"),
 
   ListItem: Ember.Object.extend({
+    currentUser: false,
     selected: false,
     item: null
   }),
+
+  sortKeys: ["currentUser:desc", "selected:desc"],
+  sortedListItems: Ember.computed.sort("listItems", "sortKeys"),
 
   actions: {
     toggleSelector: function(){

--- a/ember-app/app/components/hb-label-selector.js
+++ b/ember-app/app/components/hb-label-selector.js
@@ -15,9 +15,26 @@ var HbLabelSelectorComponent = Ember.Component.extend({
     .filter(function(item) {
       var term = this.get("filterLabels") || "";
       return item.name.toLowerCase().indexOf(term.toLowerCase()|| item.name.toLowerCase()) !== -1;
+    }.bind(this))
+    .map(function(item) {
+      return this.ListItem.create({
+        selected: this.get("selected").any(function (l){return l.name === item.name;}),
+        item: item
+      });
     }.bind(this));
 
-  }.property("filterLabels","labels"),
+  }.property("filterLabels","labels", "selected"),
+
+  ListItem: Ember.Object.extend({
+    selected: false,
+    item: null
+  }),
+
+  sortKeys: ["selected:desc", "item.name"],
+  selectedSortkeys: ["name"],
+  sortedListItems: Ember.computed.sort("listItems", "sortKeys"),
+  sortedSelected: Ember.computed.sort("selected", "selectedSortkeys"),
+
   actions: {
     toggleSelector: function(){
       this.set("isOpen", !!!this.$().is(".open"));
@@ -34,13 +51,16 @@ var HbLabelSelectorComponent = Ember.Component.extend({
     },
     select : function (label) {
       var selected = this.get("selected");
+      var currentLabel = this.get("listItems").findBy("item.name", label.name);
       var action = "";
       if(selected.isAny("name", label.name)) {
         action = "unlabel";
          selected.removeObject(selected.findBy("name", label.name));
+         Ember.set(currentLabel, "selected", false);
       } else {
         action = "label";
         selected.pushObject(label);
+        Ember.set(currentLabel, "selected", true);
       }
       this.set("values", selected);
       this.sendAction("labelsChanged", label, action);

--- a/ember-app/app/components/hb-milestone.js
+++ b/ember-app/app/components/hb-milestone.js
@@ -33,6 +33,9 @@ var HbMilestoneComponent = Ember.Component.extend({
     item: null
   }),
 
+  sortKeys: ["selected:desc", "item.title"],
+  sortedListItems: Ember.computed.sort("listItems", "sortKeys"),
+
   actions: {
     toggleSelector: function(){
       this.set("isOpen", !!!this.$().is(".open"));

--- a/ember-app/app/templates/components/hb-assignee.hbs
+++ b/ember-app/app/templates/components/hb-assignee.hbs
@@ -39,7 +39,7 @@
       </div>
     </div>
     {{/if}}
-    {{#each listItems as |listItem|}}
+    {{#each sortedListItems as |listItem|}}
     <div class="hb-menu-item {{if listItem.selected 'checked'}}">
       <div {{action "assignTo" listItem.item}} >
         <i class="ui-icon ui-icon-checkmark"></i>

--- a/ember-app/app/templates/components/hb-label-selector.hbs
+++ b/ember-app/app/templates/components/hb-label-selector.hbs
@@ -10,7 +10,7 @@
 {{/if}}
 
 <div class="hb-display-items">
-  {{#each selected as |label|}}
+  {{#each sortedSelected as |label|}}
   <div class="hb-display-item background" style={{selected-label-style label.color}}>
   <span>
     {{label.name}}
@@ -31,10 +31,10 @@
     {{input placeholder="Filter labels" value=filterLabels}}
   </div>
   <div class="hb-label-items">
-    {{#each listItems as |label|}}
-    {{#hb-label label=label}}
+    {{#each sortedListItems as |label|}}
+    {{#hb-label label=label.item}}
     <span>
-      {{label.name}}
+      {{label.item.name}}
     </span>
     {{/hb-label}}
     {{/each}}

--- a/ember-app/app/templates/components/hb-milestone.hbs
+++ b/ember-app/app/templates/components/hb-milestone.hbs
@@ -34,7 +34,7 @@
       </div>
     </div>
     {{/if}}
-    {{#each listItems as |listItem|}}
+    {{#each sortedListItems as |listItem|}}
     <div class="hb-menu-item {{if listItem.selected 'checked'}}" >
       <div {{action "assignTo" listItem.item}} >
         <i class="ui-icon ui-icon-checkmark"></i>


### PR DESCRIPTION
### This sorts the flyouts in the same manner that GitHub does.
#### For assignees, the current user is always sorted to the top, followed by the selected assignee (if there is one).

![screen shot 2015-10-27 at 10 45 58 pm](https://cloud.githubusercontent.com/assets/2813592/10778558/d0d3e47e-7cfd-11e5-825f-f224c1a61bdc.png)
#### Selected milestone

![screen shot 2015-10-27 at 10 46 42 pm](https://cloud.githubusercontent.com/assets/2813592/10778578/0614a1aa-7cfe-11e5-9488-e30487af78a4.png)
#### Selected labels

![screen shot 2015-10-27 at 10 42 58 pm](https://cloud.githubusercontent.com/assets/2813592/10778596/36a5bfde-7cfe-11e5-9007-93fcbe7333be.png)

<!---
@huboard:{"order":3.3483098706812584e-23,"milestone_order":5.483998084842208e-28,"custom_state":""}
-->
