### PR TITLE
Fixes column sorting for column indexes greater than 9

### DIFF
--- a/lib/bridge/github/labels.rb
+++ b/lib/bridge/github/labels.rb
@@ -36,7 +36,7 @@ class Huboard
         l.extend(ColumnLabel)
       end
 
-      columns = columns.sort_by {|i| i['index'] }
+      columns = columns.sort_by {|i| i['index'].to_i }
       if columns.any?
         columns.first['is_first'] = true
         columns.last['is_last'] = true


### PR DESCRIPTION
Fixes https://github.com/rauhryan/huboard/issues/605

<!---
@huboard:{"order":21.510149478912354,"milestone_order":132,"custom_state":""}
-->
