### PR TITLE
Emoji parsing for commit references 

### DIFF
--- a/ember-app/Brocfile.js
+++ b/ember-app/Brocfile.js
@@ -31,6 +31,9 @@ app.import('bower_components/jquery-color/jquery.color.js')
 app.import('app/vendor/task-list.js')
 app.import('app/vendor/autoresize.js')
 
+//Extensions
+app.import('app/utilities/core_extensions/regexp.js');
+
 
 
 module.exports = app.toTree();

--- a/ember-app/app/utilities/core_extensions/regexp.js
+++ b/ember-app/app/utilities/core_extensions/regexp.js
@@ -1,0 +1,8 @@
+(function(){
+  var special_chars = /\+|\-/g;
+  RegExp.prototype.replace = function(string){
+    return string.replace(special_chars, (match)=>{
+      return `\\${match}`;
+    });
+  };
+})();

--- a/ember-app/app/utilities/string/emoji-parser.js
+++ b/ember-app/app/utilities/string/emoji-parser.js
@@ -1,0 +1,24 @@
+import Ember from "ember";
+
+var emojiParser = Ember.Object.create({
+  parse: function(string){
+    if(!window.EMOJIS){ return string; }
+    return this._process(string);
+  },
+  _process: function(string){
+    var _self = this;
+    console.log(string.match(this._match));
+    _.each(window.EMOJIS, (value, key)=>{
+
+    });
+  },
+  _template: function(value){
+    return `<img style='height:32px;' src='${value}'></img>`;
+  },
+  _replace: function(key){
+    return `:${key}:`;
+  },
+  _match: /:([^:]*)/g
+});
+
+export default emojiParser;

--- a/ember-app/app/utilities/string/emoji-parser.js
+++ b/ember-app/app/utilities/string/emoji-parser.js
@@ -13,8 +13,7 @@ var emojiParser = Ember.Object.create({
       var emoji = window.EMOJIS[key];
       if(emoji){
         var template = _self._template(emoji);
-        var regexp = new RegExp(match, "g");
-        string = string.replace(regexp, template); 
+        string = string.replace(_self._buildRegExp(match), template);
       }
     });
     return string;
@@ -22,7 +21,11 @@ var emojiParser = Ember.Object.create({
   _template: function(value){
     return `<img style='height:32px;' src='${value}'></img>`;
   },
-  _pattern: /:(.*?):/g
+  _pattern: /:(.*?):/g,
+  _buildRegExp: function(string){
+    var escaped = new RegExp().replace(string);
+    return new RegExp(escaped, "g");
+  }
 });
 
 export default emojiParser;

--- a/ember-app/app/utilities/string/emoji-parser.js
+++ b/ember-app/app/utilities/string/emoji-parser.js
@@ -7,18 +7,22 @@ var emojiParser = Ember.Object.create({
   },
   _process: function(string){
     var _self = this;
-    console.log(string.match(this._match));
-    _.each(window.EMOJIS, (value, key)=>{
-
+    var matches = _.uniq(string.match(this._pattern));
+    matches.forEach((match)=>{
+      var key = match.replace(/:/g, "");
+      var emoji = window.EMOJIS[key];
+      if(emoji){
+        var template = _self._template(emoji);
+        var regexp = new RegExp(match, "g");
+        string = string.replace(regexp, template); 
+      }
     });
+    return string;
   },
   _template: function(value){
     return `<img style='height:32px;' src='${value}'></img>`;
   },
-  _replace: function(key){
-    return `:${key}:`;
-  },
-  _match: /:([^:]*)/g
+  _pattern: /:(.*?):/g
 });
 
 export default emojiParser;

--- a/ember-app/app/utilities/string/emoji-parser.js
+++ b/ember-app/app/utilities/string/emoji-parser.js
@@ -1,8 +1,9 @@
 import Ember from "ember";
 
 var emojiParser = Ember.Object.create({
-  parse: function(string){
+  parse: function(string, height){
     if(!window.EMOJIS){ return string; }
+    this.height = height ? height : 16;
     return this._process(string);
   },
   _process: function(string){
@@ -19,7 +20,7 @@ var emojiParser = Ember.Object.create({
     return string;
   },
   _template: function(value){
-    return `<img style='height:32px;' src='${value}'></img>`;
+    return `<img style='height:${this.height}px;' src='${value}'></img>`;
   },
   _pattern: /:(.*?):/g,
   _buildRegExp: function(string){

--- a/ember-app/app/views/issue/reference.js
+++ b/ember-app/app/views/issue/reference.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import emojiParser from "app/utilities/string/emoji-parser";
 
 var IssueReferenceView = Ember.View.extend({
   classNameBindings: [":issue-reference-info", "isLoaded:hb-loaded:ui-blur"],
@@ -7,8 +8,8 @@ var IssueReferenceView = Ember.View.extend({
   commit: null,
   commitUrl: Ember.computed.alias("commit.html_url"),
   processMessage: function(){
-    //needs emoji parser
-    this.set("message", this.get("commit.commit.message"));
+    var message = emojiParser.parse(this.get("commit.commit.message"));
+    this.set("message", message);
   }.observes("commit.commit.message"),
   shortSha: function(){
     if (this.get("commit") === null){

--- a/ember-app/app/views/issue/reference.js
+++ b/ember-app/app/views/issue/reference.js
@@ -6,7 +6,10 @@ var IssueReferenceView = Ember.View.extend({
   isLoaded: false,
   commit: null,
   commitUrl: Ember.computed.alias("commit.html_url"),
-  message: Ember.computed.alias("commit.commit.message"),
+  processMessage: function(){
+    //needs emoji parser
+    this.set("message", this.get("commit.commit.message"));
+  }.observes("commit.commit.message"),
   shortSha: function(){
     if (this.get("commit") === null){
       return "";

--- a/ember-app/app/views/issue/reference.js
+++ b/ember-app/app/views/issue/reference.js
@@ -9,7 +9,7 @@ var IssueReferenceView = Ember.View.extend({
   commitUrl: Ember.computed.alias("commit.html_url"),
   processMessage: function(){
     var message = emojiParser.parse(this.get("commit.commit.message"));
-    this.set("message", message);
+    this.set("message", message.htmlSafe());
   }.observes("commit.commit.message"),
   shortSha: function(){
     if (this.get("commit") === null){

--- a/ember-app/app/views/issue/reference.js
+++ b/ember-app/app/views/issue/reference.js
@@ -7,10 +7,10 @@ var IssueReferenceView = Ember.View.extend({
   isLoaded: false,
   commit: null,
   commitUrl: Ember.computed.alias("commit.html_url"),
-  processMessage: function(){
+  message: function(){
     var message = emojiParser.parse(this.get("commit.commit.message"));
-    this.set("message", message.htmlSafe());
-  }.observes("commit.commit.message"),
+    return message.htmlSafe();
+  }.property("commit.commit.message"),
   shortSha: function(){
     if (this.get("commit") === null){
       return "";

--- a/ember-app/tests/unit/utilities/core_extensions/regexp-test.js
+++ b/ember-app/tests/unit/utilities/core_extensions/regexp-test.js
@@ -1,0 +1,22 @@
+import {
+  module,
+  test
+} from "qunit";
+
+var sut;
+module("RegExp Extensions", {
+  setup: function(){
+    sut = new RegExp();
+  }
+});
+
+//Escape Special characters on a string (like ruby RegExp.replace)
+test("replace", (assert) =>{
+  var chars = ["+", "-"];
+  var string = "+-";
+
+  var result = sut.replace(string);
+  var expected = "\\+\\-";
+
+  assert.equal(result, expected);
+});

--- a/ember-app/tests/unit/utilities/string/emoji-parser-test.js
+++ b/ember-app/tests/unit/utilities/string/emoji-parser-test.js
@@ -10,6 +10,7 @@ module("emojiParser", {
   setup: function(){
     window.EMOJIS = EMOJIS;
     sut = emojiParser;
+    sut.height = 16;
   }
 });
 
@@ -23,10 +24,10 @@ var EMOJIS = {
 
 test("Parses emoji into img tags", (assert) =>{
   var template = sut._template;
-  var huboard = template(EMOJIS["huboard"]);
-  var github = template(EMOJIS["github"]);
-  var hundred = template(EMOJIS[100]);
-  var thumbs = template(EMOJIS["+1"]);
+  var huboard = template.call(sut, EMOJIS["huboard"]);
+  var github = template.call(sut, EMOJIS["github"]);
+  var hundred = template.call(sut, EMOJIS[100]);
+  var thumbs = template.call(sut, EMOJIS["+1"]);
 
   var target = "HuBoard is :huboard::100:, Github is :github: :100::+1:";
   var part1 = `HuBoard is ${huboard}${hundred}, `;
@@ -34,6 +35,14 @@ test("Parses emoji into img tags", (assert) =>{
 
   var result = sut.parse(target);
   assert.equal(result, (part1 + part2));
+});
+
+test("Emoji height is adjustable", (assert) =>{
+  var target = ":huboard:";
+  var expected = "<img style='height:10px;' src='https://huboardemoji.com'></img>";
+
+  var result = sut.parse(target, 10);
+  assert.equal(result, expected);
 });
 
 test("Returns the original string if nothing matches", (assert) =>{

--- a/ember-app/tests/unit/utilities/string/emoji-parser-test.js
+++ b/ember-app/tests/unit/utilities/string/emoji-parser-test.js
@@ -51,3 +51,10 @@ test("Returns the original string if nothing matches", (assert) =>{
   var result = sut.parse(target);
   assert.equal(result, target);
 });
+
+test("Does nothing with unsupported matches", (assert) =>{
+  var target = "This is a :fake: emoji";
+
+  var result = sut.parse(target);
+  assert.equal(result, target);
+});

--- a/ember-app/tests/unit/utilities/string/emoji-parser-test.js
+++ b/ember-app/tests/unit/utilities/string/emoji-parser-test.js
@@ -16,7 +16,8 @@ module("emojiParser", {
 var EMOJIS = {
   "huboard": "https://huboardemoji.com",
   "github": "https://githubemoji.com",
-  100: "https://100emoji.com"
+  100: "https://100emoji.com",
+  "+1": "https://thumbsup.com"
 };
 
 
@@ -25,10 +26,11 @@ test("Parses emoji into img tags", (assert) =>{
   var huboard = template(EMOJIS["huboard"]);
   var github = template(EMOJIS["github"]);
   var hundred = template(EMOJIS[100]);
+  var thumbs = template(EMOJIS["+1"]);
 
-  var target = "HuBoard is :huboard::100:, Github is :github: :100:"
+  var target = "HuBoard is :huboard::100:, Github is :github: :100::+1:";
   var part1 = `HuBoard is ${huboard}${hundred}, `;
-  var part2 = `Github is ${github} ${hundred}`;
+  var part2 = `Github is ${github} ${hundred}${thumbs}`;
 
   var result = sut.parse(target);
   assert.equal(result, (part1 + part2));

--- a/ember-app/tests/unit/utilities/string/emoji-parser-test.js
+++ b/ember-app/tests/unit/utilities/string/emoji-parser-test.js
@@ -33,3 +33,10 @@ test("Parses emoji into img tags", (assert) =>{
   var result = sut.parse(target);
   assert.equal(result, (part1 + part2));
 });
+
+test("Returns the original string if nothing matches", (assert) =>{
+  var target = "No Emojis here!"
+
+  var result = sut.parse(target);
+  assert.equal(result, target);
+});

--- a/ember-app/tests/unit/utilities/string/emoji-parser-test.js
+++ b/ember-app/tests/unit/utilities/string/emoji-parser-test.js
@@ -1,0 +1,35 @@
+import emojiParser from "app/utilities/string/emoji-parser";
+
+import {
+  module,
+  test
+} from "qunit";
+
+var sut;
+module("emojiParser", {
+  setup: function(){
+    window.EMOJIS = EMOJIS;
+    sut = emojiParser;
+  }
+});
+
+var EMOJIS = {
+  "huboard": "https://huboardemoji.com",
+  "github": "https://githubemoji.com",
+  100: "https://100emoji.com"
+};
+
+
+test("Parses emoji into img tags", (assert) =>{
+  var template = sut._template;
+  var huboard = template(EMOJIS["huboard"]);
+  var github = template(EMOJIS["github"]);
+  var hundred = template(EMOJIS[100]);
+
+  var target = "HuBoard is :huboard::100:, Github is :github: :100:"
+  var part1 = `HuBoard is ${huboard}${hundred}, `;
+  var part2 = `Github is ${github} ${hundred}`;
+
+  var result = sut.parse(target);
+  assert.equal(result, (part1 + part2));
+});


### PR DESCRIPTION
- Adds a parser for emojis
- Adds core extension for `RegExp.prototype.replace` modeled after ruby (narrow scope currently)

<!---
@huboard:{"order":3.161309661618673e-10,"milestone_order":143,"custom_state":""}
-->
