### PR TITLE
Hides the X icon completely from the filters

### DIFF
--- a/app/assets/stylesheets/_board.scss
+++ b/app/assets/stylesheets/_board.scss
@@ -497,6 +497,10 @@
 .filter {
 
   .ui-icon {
+    // start: UX Experiment 
+    display:none;
+    // end: UX Experiment 
+
     position: absolute;
     top: 13px;
     right: 3px;
@@ -515,6 +519,9 @@
   .dim:hover, .active:hover { 
     .ui-icon {
       display:inline;
+      // start: UX Experiment 
+      display:none;
+      // end: UX Experiment 
     }
   }
 }


### PR DESCRIPTION
Three state filters are frustrating to learn. 

Experimenting with removing the X icon