### PR TITLE
Removes an old CSS fix for label selector that causes breakage on newer versions of chrome

### DIFF
--- a/app/assets/stylesheets/components/_selector.scss
+++ b/app/assets/stylesheets/components/_selector.scss
@@ -119,7 +119,6 @@
     overflow-y: auto;
     .hb-menu-item {
       padding: 6px 12px;
-      @include transform(translateZ(0));
 
       .color {
         display: inline-block;


### PR DESCRIPTION
Removes a fix for label selector scrolling the affected older versions of chrome, which now blocks newer versions of chrome