### PR TITLE
Actually guard against missing emails

### DIFF
--- a/vendor/engines/saas/app/jobs/login_private_job.rb
+++ b/vendor/engines/saas/app/jobs/login_private_job.rb
@@ -1,7 +1,7 @@
 class LoginPrivateJob < ActiveJob::Base
 
   def perform(params)
-    if params['emails'].respond_to?('detect')
+    if params['emails'].is_a?(Array)
       email = params['emails'].detect{|e| e['primary'] == true}
       params['user']['email'] = email['email']
       params['user']['email_verified'] = email['verified']

--- a/vendor/engines/saas/app/jobs/login_public_job.rb
+++ b/vendor/engines/saas/app/jobs/login_public_job.rb
@@ -1,7 +1,7 @@
 class LoginPublicJob < ActiveJob::Base
 
   def perform(params)
-    if params['emails'].respond_to?('detect')
+    if params['emails'].is_a?(Array)
       email = params['emails'].detect{|e| e['primary'] == true}
       params['user']['email'] = email['email']
       params['user']['email_verified'] = email['verified']


### PR DESCRIPTION
Actually fixes #190. The `respond_to?` check added by #191 doesn't actually exclude a `Hash`.