### PR TITLE
Prevent opening the issue modal when clicking on the issue link

### DIFF
--- a/ember-app/app/components/hb-task-card.js
+++ b/ember-app/app/components/hb-task-card.js
@@ -42,8 +42,8 @@ var HbCardComponent = Ember.Component.extend(
       if(this.isDim(item)){return "dim";}
       return "";
     }.property("filters.hideFilters", "filters.dimFilters", "issue.milestoneTitle", "issue.other_labels.[]"),
-    click: function(){
-      if(this.get("isFiltered") === "filter-hidden"){
+    click: function(ev){
+      if(this.get("isFiltered") === "filter-hidden" || $(ev.target).is("a.xnumber")){
         return;
       }
       this.sendAction("cardClick");


### PR DESCRIPTION
Addresses: Under certain circumstances, e.g. after an issue has moved columns, clicking the issue number both opens the github issue in a new tab (desired behavior) *and* opens the issue modal (undesired behavior)
this should make it so that clicking the issue number link only ever opens the issue in a new tab

<!---
@huboard:{"order":201.0,"milestone_order":197,"custom_state":""}
-->
