### PR TITLE
Adds word-break: break-all; to card titles in order to prevent columns from growing beyond the limit

### DIFF
--- a/app/assets/stylesheets/_board.scss
+++ b/app/assets/stylesheets/_board.scss
@@ -303,6 +303,7 @@
   }
   .title {
     word-wrap: break-word;
+    word-break: break-all;
     white-space: normal;
     text-overflow: clip;
     overflow:auto;


### PR DESCRIPTION

related to huboard/huboard#631