### PR TITLE
Adds Analytics for Subscription Canceled and Trial Expired

### DIFF
--- a/lib/hu_board/account_helpers.rb
+++ b/lib/hu_board/account_helpers.rb
@@ -10,6 +10,10 @@ module HuBoard
       customer && customer[:trial] == "active"
     end
 
+    def trial_expired?(customer)
+      customer && customer[:trial] == "expired"
+    end
+
     def non_profit?(customer)
       customer[:stripe][:plan] && 
         customer[:stripe][:plan][:plan_id] == "non_profit"
@@ -21,6 +25,15 @@ module HuBoard
       if cus[:subscriptions][:total_count] > 0
         sub = cus[:subscriptions][:data][0]
         return sub[:status] == "active" || sub[:status] == "trialing"
+      end
+      false
+    end
+
+    def subscription_canceled?(customer)
+      cus = customer[:stripe][:customer]
+      if cus[:subscriptions][:total_count] > 0
+        sub = cus[:subscriptions][:data][0]
+        return sub[:status] == "canceled"
       end
       false
     end

--- a/lib/hu_board/account_helpers.rb
+++ b/lib/hu_board/account_helpers.rb
@@ -35,7 +35,7 @@ module HuBoard
         sub = cus[:subscriptions][:data][0]
         return sub[:status] == "canceled"
       end
-      false
+      true
     end
 
     def account_exists?(customer_doc)

--- a/lib/use_case/private_repo.rb
+++ b/lib/use_case/private_repo.rb
@@ -38,6 +38,9 @@ module UseCase
       if @customer && subscription_active?(@customer)
         return continue(params)
       end
+
+      params[:subscription_canceled] = subscription_canceled?(@customer)
+      params[:trial_expired] = trial_expired?(@customer)
       return fail :unauthorized
     end
 

--- a/vendor/engines/saas/app/controllers/saas/errors_controller.rb
+++ b/vendor/engines/saas/app/controllers/saas/errors_controller.rb
@@ -7,6 +7,21 @@ module Saas
         format.json { render json: { error: "Unauthenticated" }, status: 403}
       end
     end
+
+    def unauthenticated_canceled
+      respond_to do |format|
+        format.html {render :unauthenticated_canceled, status: 403}
+        format.json { render json: { error: "Canceled Subscription" }, status: 403}
+      end
+    end
+
+    def unauthenticated_expired
+      respond_to do |format|
+        format.html {render :unauthenticated_expired, status: 403}
+        format.json { render json: { error: "Trial Expired" }, status: 403}
+      end
+    end
+
     helper_method :is_owner
     helper_method :issues_enabled
     helper_method :upgrade_url

--- a/vendor/engines/saas/app/jobs/saas/errors_unauthenticated_canceled_job.rb
+++ b/vendor/engines/saas/app/jobs/saas/errors_unauthenticated_canceled_job.rb
@@ -2,8 +2,8 @@ module Saas
   class ErrorsUnauthenticatedCanceledJob < ActiveJob::Base
 
     def perform(params)
-      user = params['current_user']['login']
-      params['url'] = "/settings/#{user}/canceled"
+      owner = params['action_controller.params']['user']
+      params['url'] = "/settings/#{owner}/canceled"
       Analytics::PageJob.perform_later(params)
     end
   end

--- a/vendor/engines/saas/app/jobs/saas/errors_unauthenticated_canceled_job.rb
+++ b/vendor/engines/saas/app/jobs/saas/errors_unauthenticated_canceled_job.rb
@@ -1,0 +1,10 @@
+module Saas
+  class UnauthenticatedCanceledJob < ActiveJob::Base
+
+    def perform(params)
+      user = params['current_user']['login']
+      params['url'] = "/settings/#{user}/canceled"
+      Analytics::PageJob.perform_later(params)
+    end
+  end
+end

--- a/vendor/engines/saas/app/jobs/saas/errors_unauthenticated_canceled_job.rb
+++ b/vendor/engines/saas/app/jobs/saas/errors_unauthenticated_canceled_job.rb
@@ -1,5 +1,5 @@
 module Saas
-  class UnauthenticatedCanceledJob < ActiveJob::Base
+  class ErrorsUnauthenticatedCanceledJob < ActiveJob::Base
 
     def perform(params)
       user = params['current_user']['login']

--- a/vendor/engines/saas/app/jobs/saas/errors_unauthenticated_expired_job.rb
+++ b/vendor/engines/saas/app/jobs/saas/errors_unauthenticated_expired_job.rb
@@ -1,5 +1,5 @@
 module Saas
-  class UnauthenticatedExpiredJob < ActiveJob::Base
+  class ErrorsUnauthenticatedExpiredJob < ActiveJob::Base
 
     def perform(params)
       user = params['current_user']['login']

--- a/vendor/engines/saas/app/jobs/saas/errors_unauthenticated_expired_job.rb
+++ b/vendor/engines/saas/app/jobs/saas/errors_unauthenticated_expired_job.rb
@@ -2,8 +2,8 @@ module Saas
   class ErrorsUnauthenticatedExpiredJob < ActiveJob::Base
 
     def perform(params)
-      user = params['current_user']['login']
-      params['url'] = "/settings/#{user}/expired"
+      owner = params['action_controller.params']['user']
+      params['url'] = "/settings/#{owner}/expired"
       Analytics::PageJob.perform_later(params)
     end
   end

--- a/vendor/engines/saas/app/jobs/saas/errors_unauthenticated_expired_job.rb
+++ b/vendor/engines/saas/app/jobs/saas/errors_unauthenticated_expired_job.rb
@@ -1,0 +1,10 @@
+module Saas
+  class UnauthenticatedExpiredJob < ActiveJob::Base
+
+    def perform(params)
+      user = params['current_user']['login']
+      params['url'] = "/settings/#{user}/expired"
+      Analytics::PageJob.perform_later(params)
+    end
+  end
+end

--- a/vendor/engines/saas/app/jobs/saas/errors_unauthenticated_saas_job.rb
+++ b/vendor/engines/saas/app/jobs/saas/errors_unauthenticated_saas_job.rb
@@ -1,0 +1,10 @@
+module Saas
+  class ErrorsUnauthenticatedExpiredJob < ActiveJob::Base
+
+    def perform(params)
+      user = params['current_user']['login']
+      params['url'] = "/settings/#{user}/unauthenticated"
+      Analytics::PageJob.perform_later(params)
+    end
+  end
+end

--- a/vendor/engines/saas/app/jobs/saas/errors_unauthenticated_saas_job.rb
+++ b/vendor/engines/saas/app/jobs/saas/errors_unauthenticated_saas_job.rb
@@ -1,9 +1,9 @@
 module Saas
-  class ErrorsUnauthenticatedExpiredJob < ActiveJob::Base
+  class ErrorsUnauthenticatedSaasJob < ActiveJob::Base
 
     def perform(params)
-      user = params['current_user']['login']
-      params['url'] = "/settings/#{user}/unauthenticated"
+      owner = params['action_controller.params']['user']
+      params['url'] = "/settings/#{owner}/unauthenticated"
       Analytics::PageJob.perform_later(params)
     end
   end

--- a/vendor/engines/saas/app/views/saas/errors/unauthenticated_canceled.html.erb
+++ b/vendor/engines/saas/app/views/saas/errors/unauthenticated_canceled.html.erb
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>HuBoard :: Canceled Subscription</title>
+	<meta name="description" content="Instant project management for GitHub issues">
+  <link rel="shortcut icon" href="/favicon.ico?v=3" />
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<!-- Stylesheets -->
+	<link href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700" rel="stylesheet" type="text/css">
+  <link rel="stylesheet" href="<%= stylesheet_path "errors/main.css" %>" />
+</head>
+  <body>
+    <div class="flex-wrap">
+      <div class="flex-wrap--left">
+        <div class="message">
+          <div class="message__top">
+            <h1> ! </h1>
+            <h2> HOLD UP! </h2>
+            <h3> Your subscription for <%= params[:repo] %> has been canceled! </h3>
+          </div>
+          <% if is_owner %>
+          <div class="message__middle">
+            <p>
+            You'll need to upgrade your account to access this repo.
+            </p>
+          </div>
+          <div class="message__bottom">
+            <a href="<%= upgrade_url %>" class="call-to-action">
+              UPGRADE ACCOUNT
+            </a>
+          <% else %>
+          <div class="message__middle">
+            <p>
+              Click <a href="https://github.com/<%= params[:user] %>/<%= params[:repo] %>/issues/new?title=HuBoard%20Subscription%20Request&body=@<%= params[:user] %>%20please%20visit%20https://huboard.com/settings/profile%20to%20upgrade%20HuBoard%20for%20this%20repo" target="_blank"> here </a> if you would like to open an issue on <%= "#{params[:user]}/#{params[:repo]}" %> requesting upgraded access to HuBoard from this account
+            </p>
+          </div>
+          <div class="message__bottom">
+            <a href="/" class="call-to-action">
+             BACK HOME 
+            </a>
+          <% end %>
+          </div>
+        </div>
+      </div>
+      <div class="flex-wrap--right illustration illustration--policeman">
+      </div>
+    </div>
+     <%= render partial: 'shared/fontdeck' %>
+  </body>
+</html>
+
+

--- a/vendor/engines/saas/app/views/saas/errors/unauthenticated_canceled.html.erb
+++ b/vendor/engines/saas/app/views/saas/errors/unauthenticated_canceled.html.erb
@@ -18,12 +18,12 @@
           <div class="message__top">
             <h1> ! </h1>
             <h2> HOLD UP! </h2>
-            <h3> Your subscription for <%= params[:repo] %> has been canceled! </h3>
+            <h3> Your subscription for <%= params[:user] %> has been canceled! </h3>
           </div>
           <% if is_owner %>
           <div class="message__middle">
             <p>
-            You'll need to upgrade your account to access this repo.
+            You'll need to upgrade your account to access <%= params[:user] %>/<%= params[:repo] %>
             </p>
           </div>
           <div class="message__bottom">

--- a/vendor/engines/saas/app/views/saas/errors/unauthenticated_expired.html.erb
+++ b/vendor/engines/saas/app/views/saas/errors/unauthenticated_expired.html.erb
@@ -18,12 +18,12 @@
           <div class="message__top">
             <h1> ! </h1>
             <h2> HOLD UP! </h2>
-            <h3> Your trial for <%= params[:repo] %> has expired! </h3>
+            <h3> Your trial for <%= params[:user] %> has expired! </h3>
           </div>
           <% if is_owner %>
           <div class="message__middle">
             <p>
-            You'll need to upgrade your account to access this repo.
+            You'll need to upgrade your account to access <%= params[:user] %>/<%= params[:repo] %>
             </p>
           </div>
           <div class="message__bottom">
@@ -33,7 +33,7 @@
           <% else %>
           <div class="message__middle">
             <p>
-              Click <a href="https://github.com/<%= params[:user] %>/<%= params[:repo] %>/issues/new?title=HuBoard%20Subscription%20Request&body=@<%= params[:user] %>%20please%20visit%20https://huboard.com/settings/profile%20to%20upgrade%20HuBoard%20for%20this%20repo" target="_blank"> here </a> if you would like to open an issue on <%= "#{params[:user]}/#{params[:repo]}" %> requesting upgraded access to HuBoard from this account
+              Click <a href="https://github.com/<%= params[:user] %>/<%= params[:repo] %>/issues/new?title=HuBoard%20Subscription%20Request&body=@<%= params[:user] %>%20please%20visit%20https://huboard.com/settings/profile%20to%20upgrade%20HuBoard%20for%20this%20repo" target="_blank"> here </a> if you would like to open an issue on <%= "#{params[:user]}/#{params[:repo]}" %> requesting upgraded access
             </p>
           </div>
           <div class="message__bottom">

--- a/vendor/engines/saas/app/views/saas/errors/unauthenticated_expired.html.erb
+++ b/vendor/engines/saas/app/views/saas/errors/unauthenticated_expired.html.erb
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>HuBoard :: Trial Expired</title>
+	<meta name="description" content="Instant project management for GitHub issues">
+  <link rel="shortcut icon" href="/favicon.ico?v=3" />
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<!-- Stylesheets -->
+	<link href="//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700" rel="stylesheet" type="text/css">
+  <link rel="stylesheet" href="<%= stylesheet_path "errors/main.css" %>" />
+</head>
+  <body>
+    <div class="flex-wrap">
+      <div class="flex-wrap--left">
+        <div class="message">
+          <div class="message__top">
+            <h1> ! </h1>
+            <h2> HOLD UP! </h2>
+            <h3> Your trial for <%= params[:repo] %> has expired! </h3>
+          </div>
+          <% if is_owner %>
+          <div class="message__middle">
+            <p>
+            You'll need to upgrade your account to access this repo.
+            </p>
+          </div>
+          <div class="message__bottom">
+            <a href="<%= upgrade_url %>" class="call-to-action">
+              UPGRADE ACCOUNT
+            </a>
+          <% else %>
+          <div class="message__middle">
+            <p>
+              Click <a href="https://github.com/<%= params[:user] %>/<%= params[:repo] %>/issues/new?title=HuBoard%20Subscription%20Request&body=@<%= params[:user] %>%20please%20visit%20https://huboard.com/settings/profile%20to%20upgrade%20HuBoard%20for%20this%20repo" target="_blank"> here </a> if you would like to open an issue on <%= "#{params[:user]}/#{params[:repo]}" %> requesting upgraded access to HuBoard from this account
+            </p>
+          </div>
+          <div class="message__bottom">
+            <a href="/" class="call-to-action">
+             BACK HOME 
+            </a>
+          <% end %>
+          </div>
+        </div>
+      </div>
+      <div class="flex-wrap--right illustration illustration--policeman">
+      </div>
+    </div>
+     <%= render partial: 'shared/fontdeck' %>
+  </body>
+</html>
+
+

--- a/vendor/engines/saas/config/routes.rb
+++ b/vendor/engines/saas/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do 
   match 'unauthenticated_saas' => 'saas/errors#unauthenticated_saas', via: :all
+  match 'unauthenticated_canceled' => 'saas/errors#unauthenticated_canceled', via: :all
+  match 'unauthenticated_expired' => 'saas/errors#unauthenticated_expired', via: :all
   mount Saas::Engine => "/settings"
   scope "/api" do
     get '/profiles'      => "saas/profiles#index"

--- a/vendor/engines/saas/lib/saas/before_action.rb
+++ b/vendor/engines/saas/lib/saas/before_action.rb
@@ -29,7 +29,7 @@ module Saas
               throw :warden, action: 'unauthenticated_canceled'
             end
 
-            if params[:trial_expired] && !params[:subscription_canceled]
+            if params[:trial_expired]
               throw :warden, action: 'unauthenticated_expired'
             end
 

--- a/vendor/engines/saas/lib/saas/before_action.rb
+++ b/vendor/engines/saas/lib/saas/before_action.rb
@@ -25,6 +25,14 @@ module Saas
           end
 
           failure :unauthorized do
+            if params[:subscription_canceled]
+              throw :warden, action: 'unauthenticated_canceled'
+            end
+
+            if params[:trial_expired] && !params[:subscription_canceled]
+              throw :warden, action: 'unauthenticated_expired'
+            end
+
             throw :warden, action: 'unauthenticated_saas'
           end
         end


### PR DESCRIPTION
- Splits out unauthenticed action on `Saas::ErrorController` to `unauthenticated_canceled` & `unauthenticated_expired` (along with discrete views)
- Adds conventional jobs for both actions
- Pages on Subscription Canceled and Trial Expired 

References #179