### PR TITLE
Fixes link tab being broken

### DIFF
--- a/ember-app/app/components/hb-column-crumb.js
+++ b/ember-app/app/components/hb-column-crumb.js
@@ -6,6 +6,7 @@ var HbColumnCrumbComponent = Ember.Component.extend({
   classNameBindings: ["stateClass", "isSelected:active:inactive", "indexClass"],
   isSelected: function(){
     var current_issue = this.get("issue");
+    if(!current_issue){ return false; }
     return this.get("column.sortedIssues").find((issue)=> {
       return issue.get("id") === current_issue.get("id");
     });


### PR DESCRIPTION
When the prior "isSelected" bug was fix by recomputing based on an issue, it was neglected that the link page also uses the same component. This is now broken when isSelected tries to compute and cannot find and issue.