### PR TITLE
Resolves gemspec deprecation warnings on the Rails engine and Faye Extensions

### DIFF
--- a/vendor/engines/saas/saas.gemspec
+++ b/vendor/engines/saas/saas.gemspec
@@ -9,9 +9,9 @@ Gem::Specification.new do |s|
   s.version     = Saas::VERSION
   s.authors     = [""]
   s.email       = [""]
-  s.homepage    = "TODO"
-  s.summary     = "TODO: Summary of Saas."
-  s.description = "TODO: Description of Saas."
+  s.homepage    = "https://huboard.com"
+  s.summary     = "A simple, lightweight kanban board for GitHub"
+  s.description = "Saas Module for HuBoard"
   s.license     = "MIT"
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]

--- a/vendor/gems/faye_extensions/faye_extensions.gemspec
+++ b/vendor/gems/faye_extensions/faye_extensions.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.version     = FayeExtensions::VERSION
   s.authors     = [""]
   s.email       = [""]
-  s.homepage    = "https://github.com/huboard/huboard-web/vender/gems/faye_extensions"
+  s.homepage    = "https://github.com/huboard/huboard-web/tree/master/vendor/gems/faye_extensions "
   s.summary     = "HuBoard Extensions for Faye"
   s.description = "HuBoard Extensions for Faye"
   s.license     = "MIT"

--- a/vendor/gems/faye_extensions/faye_extensions.gemspec
+++ b/vendor/gems/faye_extensions/faye_extensions.gemspec
@@ -9,9 +9,9 @@ Gem::Specification.new do |s|
   s.version     = FayeExtensions::VERSION
   s.authors     = [""]
   s.email       = [""]
-  s.homepage    = "TODO"
-  s.summary     = "TODO: Summary of Saas."
-  s.description = "TODO: Description of Saas."
+  s.homepage    = "https://github.com/huboard/huboard-web/vender/gems/faye_extensions"
+  s.summary     = "HuBoard Extensions for Faye"
+  s.description = "HuBoard Extensions for Faye"
   s.license     = "MIT"
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]

--- a/vendor/gems/faye_extensions/faye_extensions.gemspec
+++ b/vendor/gems/faye_extensions/faye_extensions.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.version     = FayeExtensions::VERSION
   s.authors     = [""]
   s.email       = [""]
-  s.homepage    = "https://github.com/huboard/huboard-web/tree/master/vendor/gems/faye_extensions "
+  s.homepage    = "https://github.com/huboard/huboard-web/tree/master/vendor/gems/faye_extensions"
   s.summary     = "HuBoard Extensions for Faye"
   s.description = "HuBoard Extensions for Faye"
   s.license     = "MIT"


### PR DESCRIPTION
This was blocking our deployments to heroku as of this build pack deploy: https://github.com/heroku/heroku-buildpack-ruby/pull/461

The deprecations look something like this:
![image](https://cloud.githubusercontent.com/assets/1130665/13337035/7bf3ac5e-dbd6-11e5-90c2-8007291d10d3.png)

On deploy they would literally prevent `analytics-ruby` from the rails engine `gemspec` from installing.

Take a look at the diff to see the offending code, pretty weird that `'TODO'` strings would cause such a fuss.
