### PR TITLE
Implement Heroku Review Apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -51,6 +51,9 @@
     "HEROKU_APP_NAME": {
       "required": true
     },
+    "HEROKU_PARENT_APP_NAME": {
+      "required": true
+    },
     "HEROKU_RELEASE_VERSION": {
       "required": true
     },

--- a/app.json
+++ b/app.json
@@ -1,0 +1,127 @@
+{
+  "name": "huboard-web",
+  "scripts": {
+  },
+  "env": {
+    "AWS_ACCESS_KEY_ID": {
+      "required": true
+    },
+    "AWS_S3_BUCKET": {
+      "required": true
+    },
+    "AWS_SECRET_ACCESS_KEY": {
+      "required": true
+    },
+    "BUILDPACK_URL": {
+      "required": true
+    },
+    "CLOUDFRONT_URL": {
+      "required": true
+    },
+    "COUCH_DATABASE": {
+      "required": true
+    },
+    "COUCH_URL": {
+      "required": true
+    },
+    "ELASTICSEARCH_URL": {
+      "required": true
+    },
+    "GITHUB_API_ENDPOINT": {
+      "required": true
+    },
+    "GITHUB_AUTH_STRATEGY": {
+      "required": true
+    },
+    "GITHUB_CLIENT_ID": {
+      "required": true
+    },
+    "GITHUB_SECRET": {
+      "required": true
+    },
+    "GITHUB_WEB_ENDPOINT": {
+      "required": true
+    },
+    "GITHUB_WEBHOOK_ENDPOINT": {
+      "required": true
+    },
+    "HEROKU_APP_ID": {
+      "required": true
+    },
+    "HEROKU_APP_NAME": {
+      "required": true
+    },
+    "HEROKU_RELEASE_VERSION": {
+      "required": true
+    },
+    "HEROKU_SLUG_COMMIT": {
+      "required": true
+    },
+    "HEROKU_SLUG_DESCRIPTION": {
+      "required": true
+    },
+    "HUBOARD_ENV": {
+      "required": true
+    },
+    "LANG": {
+      "required": true
+    },
+    "MAX_THREADS": {
+      "required": true
+    },
+    "RACK_ENV": {
+      "required": true
+    },
+    "RAILS_ENV": {
+      "required": true
+    },
+    "RAILS_SERVE_STATIC_FILES": {
+      "required": true
+    },
+    "RAYGUN_APIKEY": {
+      "required": true
+    },
+    "REDIS_URL": {
+      "required": true
+    },
+    "SECRET_KEY": {
+      "required": true
+    },
+    "SECRET_KEY_BASE": {
+      "required": true
+    },
+    "SEGEMENTIO_KEY": {
+      "required": true
+    },
+    "SEGMENTIO_KEY": {
+      "required": true
+    },
+    "SESSION_SECRET": {
+      "required": true
+    },
+    "SOCKET_BACKEND": {
+      "required": true
+    },
+    "STRIPE_API": {
+      "required": true
+    },
+    "STRIPE_PUBLISHABLE_API": {
+      "required": true
+    },
+    "STRIPE_SECRET_KEY": {
+      "required": true
+    },
+    "WARDEN_GITHUB_VERIFIER_SECRET": {
+      "required": true
+    }
+  },
+  "addons": [
+    "rediscloud",
+    "memcachier"
+  ],
+  "buildpacks": [
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-multi"
+    }
+  ]
+}

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -21,3 +21,16 @@ end
 Warden::Manager.serialize_from_session { |key| Warden::GitHub::Verifier.load(key) }
 Warden::Manager.serialize_into_session { |user| Warden::GitHub::Verifier.dump(user) }
 
+module Warden
+  module GitHub
+    class Config
+      alias_method :base_normalized_uri, :normalized_uri
+
+      def normalized_uri(uri_or_path)
+        uri = base_normalized_uri(uri_or_path)
+        puts "Warden Override: #{uri}"
+        uri
+      end
+    end
+  end
+end

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -21,6 +21,8 @@ end
 Warden::Manager.serialize_from_session { |key| Warden::GitHub::Verifier.load(key) }
 Warden::Manager.serialize_into_session { |user| Warden::GitHub::Verifier.dump(user) }
 
+require 'uri'
+
 module Warden
   module GitHub
     class Config
@@ -28,6 +30,15 @@ module Warden
 
       def normalized_uri(uri_or_path)
         uri = base_normalized_uri(uri_or_path)
+
+        app_name = ENV["HEROKU_APP_NAME"]
+        parent_app_name = ENV["HEROKU_PARENT_APP_NAME"]
+        puts "Warden Override: #{app_name} => #{parent_app_name}"
+        if parent_app_name && parent_app_name != app_name
+          uri.host.sub! app_name, parent_app_name
+          uri.query = URI.encode_www_form("APP_NAME" => app_name)
+        end
+
         puts "Warden Override: #{uri}"
         uri
       end

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -33,13 +33,13 @@ module Warden
 
         app_name = ENV["HEROKU_APP_NAME"]
         parent_app_name = ENV["HEROKU_PARENT_APP_NAME"]
-        puts "Warden Override: #{app_name} => #{parent_app_name}"
+        Rails.logger.info "Warden Override: #{app_name} => #{parent_app_name}"
         if parent_app_name && parent_app_name != app_name
           uri.host.sub! app_name, parent_app_name
           uri.query = URI.encode_www_form("APP_NAME" => app_name)
         end
 
-        puts "Warden Override: #{uri}"
+        Rails.logger.info "Warden Override: #{uri}"
         uri
       end
     end
@@ -59,13 +59,13 @@ class Huboard
 
         app_name = uri.query_values['APP_NAME'] if uri.query_values
         parent_app_name = ENV['HEROKU_APP_NAME']
-        puts "AppRedirect: #{parent_app_name} => #{app_name}"
+        Rails.logger.info "AppRedirect: #{parent_app_name} => #{app_name}"
 
         if app_name && parent_app_name
           uri.query_values = uri.query_values(Array).reject { |kvp| kvp[0] == 'APP_NAME' } unless !uri.query_values
 
           app_redirect = "#{env['rack.url_scheme']}://#{env['HTTP_HOST'].sub(parent_app_name, app_name)}#{uri}"
-          puts "AppRedirect to #{app_redirect}"
+          Rails.logger.info "AppRedirect to #{app_redirect}"
           return [302, {"Location" => app_redirect}, self]
         end
 

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -59,7 +59,7 @@ class Huboard
 
         app_name = uri.query_values['APP_NAME'] if uri.query_values
         parent_app_name = ENV['HEROKU_APP_NAME']
-        Rails.logger.info "AppRedirect: #{parent_app_name} => #{app_name}"
+        Rails.logger.info "AppRedirect: #{parent_app_name} => #{app_name}" if app_name
 
         if app_name && parent_app_name
           uri.query_values = uri.query_values(Array).reject { |kvp| kvp[0] == 'APP_NAME' } unless !uri.query_values


### PR DESCRIPTION
Closes #183. As [discussed](https://github.com/huboard/huboard-web/issues/183#issuecomment-181741222), due to OAuth host constraints this isn't as trivial as it would be for a simple app.

- [x] Add `app.json` review app config, mostly generated by Heroku.

    I did manually add `HEROKU_PARENT_APP_NAME`, which I wish they had included in the generated file. It took me a _long_ time to figure out that `app.json` only matters when a review app is first created - this second commit didn't take effect until I deleted the existing review app. Much time wasted here.

- [x] Override [`Warden::GitHub::Config.normalized_uri()`](https://github.com/atmos/warden-github/blob/3e9aa5fa55d52a0cf8d0cd69ecfb07ce1d5fc03a/lib/warden/github/config.rb#L115-L122) to do two things:

    1. Update `host` with the parent app name instead of the current app name.
    2. Append an `APP_NAME` query string with the current app name, so we can redirect back to it.

- [x] <del>Update `LoginController`</del> Add middleware to check for `APP_NAME` so we can redirect to review apps from the parent app as necessary.