### PR TITLE
Fixes Issue Event Job fails tied to a Rails Upgrade

### DIFF
--- a/app/jobs/issue_event_job.rb
+++ b/app/jobs/issue_event_job.rb
@@ -19,6 +19,7 @@ class IssueEventJob < ActiveJob::Base
   end
 
   def self.build_meta(params)
+    #TODO Fix this hack on remapping params to HWIA
     params = HashWithIndifferentAccess.new(params)
     issue = HashWithIndifferentAccess.new(params['issue'])
     action = @_action.is_a?(String) ? @_action : @_action.call(params)

--- a/app/jobs/issue_event_job.rb
+++ b/app/jobs/issue_event_job.rb
@@ -19,6 +19,7 @@ class IssueEventJob < ActiveJob::Base
   end
 
   def self.build_meta(params)
+    params = HashWithIndifferentAccess.new(params)
     issue = HashWithIndifferentAccess.new(params['issue'])
     action = @_action.is_a?(String) ? @_action : @_action.call(params)
     HashWithIndifferentAccess.new(


### PR DESCRIPTION
Following upgrade https://github.com/huboard/huboard-web/pull/217, we discovered ActiveJob's serialize/deserialize was no longer providing `HashWithIndifferentAccess` hashes in certain contexts, this is one of those cases. 

Fixes #220.