### PR TITLE
Adds analytics for upgraded & canceled subscriptions

### DIFF
--- a/vendor/engines/saas/app/controllers/saas/plans_controller.rb
+++ b/vendor/engines/saas/app/controllers/saas/plans_controller.rb
@@ -32,6 +32,9 @@ module Saas
         plan_doc.trial = "expired"
         couch.customers.save plan_doc
 
+        @event = 'plan_canceled'
+        @repo_owner = plan_doc.github.account.login
+
         render json: {success: true, message: "Sorry to see you go"}
       else
         render json: {success: false, message: "Unable to find plan"}

--- a/vendor/engines/saas/app/controllers/saas/plans_controller.rb
+++ b/vendor/engines/saas/app/controllers/saas/plans_controller.rb
@@ -32,7 +32,7 @@ module Saas
         plan_doc.trial = "expired"
         couch.customers.save plan_doc
 
-        @event = 'plan_canceled'
+        @event = 'plan_canceling'
         @repo_owner = plan_doc.github.account.login
 
         render json: {success: true, message: "Sorry to see you go"}

--- a/vendor/engines/saas/app/jobs/saas/charges_create_job.rb
+++ b/vendor/engines/saas/app/jobs/saas/charges_create_job.rb
@@ -5,7 +5,11 @@ module Saas
       Analytics::IdentifyUserJob.perform_later(params)
       Analytics::TrackUserJob.perform_later(params)
       Analytics::GroupOwnerJob.perform_later(params)
-    end
 
+      if params[:event]
+        params['url'] = "/settings/#{params[:repo_owner]['login']}/upgrading"
+        Analytics::PageJob.perform_later(params)
+      end
+    end
   end
 end

--- a/vendor/engines/saas/app/jobs/saas/charges_create_job.rb
+++ b/vendor/engines/saas/app/jobs/saas/charges_create_job.rb
@@ -6,7 +6,7 @@ module Saas
       Analytics::TrackUserJob.perform_later(params)
       Analytics::GroupOwnerJob.perform_later(params)
 
-      if params[:event]
+      if params[:event] == 'customer_subscribed'
         params['url'] = "/settings/#{params[:repo_owner]['login']}/upgrading"
         Analytics::PageJob.perform_later(params)
       end

--- a/vendor/engines/saas/app/jobs/saas/plans_destroy_job.rb
+++ b/vendor/engines/saas/app/jobs/saas/plans_destroy_job.rb
@@ -2,8 +2,8 @@ module Saas
   class PlansDestroyJob < ActiveJob::Base
 
     def perform(params)
-      if params[:event] == 'plan_canceled'
-        params['url'] = "/settings/#{params[:repo_owner]}/canceled"
+      if params[:event] == 'plan_canceling'
+        params['url'] = "/settings/#{params[:repo_owner]}/canceling"
         Analytics::PageJob.perform_later(params)
       end
     end

--- a/vendor/engines/saas/app/jobs/saas/plans_destroy_job.rb
+++ b/vendor/engines/saas/app/jobs/saas/plans_destroy_job.rb
@@ -1,0 +1,11 @@
+module Saas
+  class PlansDestroyJob < ActiveJob::Base
+
+    def perform(params)
+      if params[:event] == 'plan_canceled'
+        params['url'] = "/settings/#{params[:repo_owner]}/canceled"
+        Analytics::PageJob.perform_later(params)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`/settings/{owner}/upgrade` when Upgrade is clicked (popping Stripe modal) is blocked by #158/#189/#209