### PR TITLE
Add Vagrant .bashrc

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,2 +1,12 @@
 #!/usr/bin/env bash
 cd /srv/huboard
+alias i="bundle install"
+alias s="bundle exec rails server --binding 0.0.0.0"
+
+echo "
+Welcome to Huboard!
+
+1. If you haven't already, run 'i' to install dependencies.
+2. Run 's' to start Rails.
+3. Browse to http://localhost:3001/ from your host.
+"

--- a/.bashrc
+++ b/.bashrc
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+cd /srv/huboard

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+.bashrc eol=lf

--- a/puppet/manifests/base.pp
+++ b/puppet/manifests/base.pp
@@ -98,8 +98,8 @@ package {
       createrole    => true,
     }
 
-  exec { "echo 'cd /srv/huboard' >> .bashrc":
+  exec { "echo 'source /srv/huboard/.bashrc' >> .bashrc":
     cwd    => "/home/vagrant",
     path   => "/usr/bin:/usr/sbin:/bin",
-    unless => "grep -q '^cd /srv/huboard$' .bashrc"
+    unless => "grep -q '^source /srv/huboard/\.bashrc$' .bashrc"
   }


### PR DESCRIPTION
My initial goal was an alias to simplify running the app (I picked `s` in honor of `rails s`, but am not attached to it).

As a means to that end, I introduced a `.bashrc` to be referenced from Vagrant. Should make iterating on that experience easier.

<!---
@huboard:{"milestone_order":1.5000000000000386,"order":2.0216210539962315e-23,"custom_state":""}
-->
