### PR TITLE
Consistent Word Break Handling

### DIFF
--- a/app/assets/stylesheets/_board.scss
+++ b/app/assets/stylesheets/_board.scss
@@ -302,8 +302,6 @@
     color: $darkGrey;
   }
   .title {
-    word-wrap: break-word;
-    @include word-break(break-word);
     white-space: normal;
     text-overflow: clip;
     overflow:auto;

--- a/app/assets/stylesheets/_issue.scss
+++ b/app/assets/stylesheets/_issue.scss
@@ -57,7 +57,6 @@
 }
 
 .flex-issue-title {
-  @include word-break(break-word);
   @include display(flex);
   .issue-closed-badge p {
     margin: 4px 4px;

--- a/app/assets/stylesheets/_mixins.scss
+++ b/app/assets/stylesheets/_mixins.scss
@@ -91,7 +91,3 @@
     transform: translate(0, 2px);
   }
 }
-
-@mixin word-break($value) {
-  @include prefixer(word-break, $value, webkit moz ms spec);
-}

--- a/app/assets/stylesheets/_overlay.scss
+++ b/app/assets/stylesheets/_overlay.scss
@@ -154,15 +154,6 @@ body > .fullscreen-overlay {
 }
 .fullscreen-card-description {
   p {
-  -ms-word-break: break-all;
-     word-break: break-all;
-
-     // Non standard for webkit
-     word-break: break-word;
-
--webkit-hyphens: auto;
-   -moz-hyphens: auto;
-        hyphens: auto;
   }
 }
 .fullscreen-card-right{
@@ -250,16 +241,7 @@ body > .fullscreen-overlay {
     }
   }
   .comment-text {
-      -ms-word-break: break-all;
-      word-break: break-all;
-
-      // Non standard for webkit
-      word-break: break-word;
-
-      -webkit-hyphens: auto;
-      -moz-hyphens: auto;
-      hyphens: auto;
-    }
+  }
 
 }
 

--- a/app/assets/stylesheets/flex_layout.css.scss
+++ b/app/assets/stylesheets/flex_layout.css.scss
@@ -47,6 +47,10 @@ body {
   overflow-wrap: break-word;
 }
 
+.wrap-fix {
+  min-width: 0;
+}
+
 [draggable] {
   -khtml-user-drag: element;
   -webkit-user-drag: element;
@@ -188,6 +192,7 @@ body {
 
 .board-not-dragging {
   .column.milestone {
+    min-width: 0;
     @include display(flex);
     @include flex-direction(column);
     @include flex(0 0 230px);
@@ -291,6 +296,7 @@ body {
 
 .task-column {
   float:none;
+  min-width: 0;
   @include flex(1);
   @include display(flex);
   @include flex-direction(column);

--- a/app/assets/stylesheets/flex_layout.css.scss
+++ b/app/assets/stylesheets/flex_layout.css.scss
@@ -42,6 +42,11 @@
    @include flex-direction(column);
 }
 
+body {
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+}
+
 [draggable] {
   -khtml-user-drag: element;
   -webkit-user-drag: element;

--- a/app/assets/stylesheets/flex_layout.css.scss
+++ b/app/assets/stylesheets/flex_layout.css.scss
@@ -385,6 +385,7 @@ body {
    }
 }
 .board {
+  max-width: 100%;
   @include display(flex);
   @include flex(1);
   @include align-content(stretch);

--- a/ember-app/app/templates/components/issue/hb-title.hbs
+++ b/ember-app/app/templates/components/issue/hb-title.hbs
@@ -12,7 +12,7 @@
     {{input value=bufferedContent.title }}
   {{else}}
     <div class="flex-issue-title">
-      {{ model.title }}
+      <span class="wrap-fix">{{ model.title }}</span>
       <a class="number" href="{{{unbound model.html_url }}}" target="_blank" title="{{model.title}}"><small>#{{model.number}}</small></a>
       {{#if isClosed}}
         <span class="issue-closed-badge"><p> Closed </p></span>
@@ -20,4 +20,3 @@
     </div>
   {{/if}}
 </h2>
-


### PR DESCRIPTION
Closes #205 using a global `word-wrap: break-word` rule plus a few `min-width:0` hacks due to Firefox ([supposedly spec-defined](https://bugzilla.mozilla.org/show_bug.cgi?id=1136818#c11)) interaction between `word-wrap` and Flexbox.