### PR TITLE
Routes 503's and 400's to 'server_error'

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
   match '/404', to: 'errors#not_found', constraints: { status: /\d{3}/ }, via: :all
   match '/422', to: 'errors#unprocessable_entity', constraints: { status: /\d{3}/ }, via: :all
   match '/500', to: 'errors#server_error', constraints: { status: /\d{3}/ }, via: :all
+  match '/503', to: 'errors#server_error', constraints: { status: /\d{3}/ }, via: :all
+  match '/400', to: 'errors#server_error', constraints: { status: /\d{3}/ }, via: :all
   match '/403', to: 'errors#server_error', constraints: { status: /\d{3}/ }, via: :all
   match 'unauthenticated', to: 'errors#unauthenticated', via: :all
 


### PR DESCRIPTION
When the GitHub API goes down currently users are greeting with ugly plain-text pages - this PR routes them to the server-error endpoint.