### PR TITLE
Actually suppress publishing same-column milestone moves

### DIFF
--- a/app/jobs/api/issues_assign_milestone_job.rb
+++ b/app/jobs/api/issues_assign_milestone_job.rb
@@ -4,16 +4,17 @@ module Api
     action 'milestone_changed'
     timestamp Proc.new { Time.now.utc.iso8601}
 
-    ## don't perform if the milestone didn't change
+    ## suppress if the milestone didn't change
     #
     before_perform :only_if_changed
     def only_if_changed
       params = arguments.first
-      params[:changed_milestones]
+      params[:suppress] = !params[:changed_milestones]
     end
 
     def payload(params)
       {
+        suppress: params[:suppress],
         issue: params[:issue],
         milestone: params[:issue]['milestone']
       }

--- a/app/jobs/issue_event_job.rb
+++ b/app/jobs/issue_event_job.rb
@@ -47,6 +47,8 @@ class IssueEventJob < ActiveJob::Base
   def perform(params)
     message = deliver payload(params)
 
+    return if params[:suppress]
+
     PublishWebhookJob.perform_later message if self.class.included_modules.include? IsPublishable
   end
 

--- a/ember-app/app/components/hb-milestone.js
+++ b/ember-app/app/components/hb-milestone.js
@@ -47,14 +47,14 @@ var HbMilestoneComponent = Ember.Component.extend({
       }
     },
     assignTo: function(milestone) {
-      this.set("selected", milestone);
       this.sendAction("assign", milestone);
+      this.set("selected", milestone);
       this.$().removeClass("open");
       this.set("isOpen", false);
     },
     clearMilestone: function(){
-      this.set("selected", null);
       this.sendAction("assign", "");
+      this.set("selected", null);
       this.$().removeClass("open");
       this.set("isOpen", false);
     }

--- a/ember-app/app/mixins/subscriptions/board.js
+++ b/ember-app/app/mixins/subscriptions/board.js
@@ -115,12 +115,9 @@ var BoardSubscriptionMixin = Ember.Mixin.create({
 
       var actor = message.actor.login;
       var milestone = message.issue.milestone;
+      var title = milestone ? milestone.title : 'No Milestone';
 
-      if(milestone){
-        var copy = `${actor} changed milestone of #${message.issue.number} to ${milestone.title}`;
-      } else {
-        var copy = `${actor} removed milestone from #${message.issue.number}`;
-      }
+      var copy = `${actor} changed milestone of #${message.issue.number} to ${title}`;
 
       this.get("flashMessages").info(copy);
     },

--- a/ember-app/app/mixins/subscriptions/board.js
+++ b/ember-app/app/mixins/subscriptions/board.js
@@ -111,6 +111,8 @@ var BoardSubscriptionMixin = Ember.Mixin.create({
       this.get("flashMessages").info(copy);
     },
     issueMsChanged: function(message){
+      if (message.suppress) { return; }
+
       var actor = message.actor.login;
       var milestone = message.issue.milestone;
 

--- a/ember-app/app/mixins/subscriptions/board.js
+++ b/ember-app/app/mixins/subscriptions/board.js
@@ -119,7 +119,7 @@ var BoardSubscriptionMixin = Ember.Mixin.create({
       if(milestone){
         var copy = `${actor} changed milestone of #${message.issue.number} to ${milestone.title}`;
       } else {
-        var copy = `${actor} changed milestone of #${message.issue.number} to _nil_`;
+        var copy = `${actor} removed milestone from #${message.issue.number}`;
       }
 
       this.get("flashMessages").info(copy);

--- a/lib/hu_board/services/slack.rb
+++ b/lib/hu_board/services/slack.rb
@@ -82,35 +82,20 @@ module HuBoard
     end
 
     def transform_milestone_changed(mash)
-      if mash.payload.milestone.nil?
-        {
-          username: "#{mash.meta.user.login} via HuBoard",
-          icon_url: avatar_url(mash),
-          attachments: [
-            {
-              fallback: "<#{URI.join(github_url,mash.meta.user.login)}|@#{mash.meta.user.login}> changed milestone of <#{mash.payload.issue.html_url}|#{mash.meta.repo_full_name}##{mash.payload.issue.number}> to _nil_",
-              pretext: "<#{URI.join(github_url,mash.meta.user.login)}|@#{mash.meta.user.login}> changed milestone of <#{mash.payload.issue.html_url}|#{mash.meta.repo_full_name}##{mash.payload.issue.number}> to _nil_",
-              text: "*Title*: #{mash.payload.issue.title}",
-              mrkdwn_in: ["text","fields","pretext"],
-                unfurl_links: true
-            }
-          ]
-        }
-      else
-        {
-          username: "#{mash.meta.user.login} via HuBoard",
-          icon_url: avatar_url(mash),
-          attachments: [
-            {
-              fallback: "<#{URI.join(github_url,mash.meta.user.login)}|@#{mash.meta.user.login}> changed milestone of <#{mash.payload.issue.html_url}|#{mash.meta.repo_full_name}##{mash.payload.issue.number}> to *#{mash.payload.milestone.title}*",
-              pretext: "<#{URI.join(github_url,mash.meta.user.login)}|@#{mash.meta.user.login}> changed milestone of <#{mash.payload.issue.html_url}|#{mash.meta.repo_full_name}##{mash.payload.issue.number}> to *#{mash.payload.milestone.title}*",
-              text: "*Title*: #{mash.payload.issue.title}",
-              mrkdwn_in: ["text","fields","pretext"],
-                unfurl_links: true
-            }
-          ]
-        }
-      end
+      milestone = mash.payload.milestone.nil? ? "No Milestone" : mash.payload.milestone.title
+      {
+        username: "#{mash.meta.user.login} via HuBoard",
+        icon_url: avatar_url(mash),
+        attachments: [
+          {
+            fallback: "<#{URI.join(github_url,mash.meta.user.login)}|@#{mash.meta.user.login}> changed milestone of <#{mash.payload.issue.html_url}|#{mash.meta.repo_full_name}##{mash.payload.issue.number}> to *#{milestone}*",
+            pretext: "<#{URI.join(github_url,mash.meta.user.login)}|@#{mash.meta.user.login}> changed milestone of <#{mash.payload.issue.html_url}|#{mash.meta.repo_full_name}##{mash.payload.issue.number}> to *#{milestone}*",
+            text: "*Title*: #{mash.payload.issue.title}",
+            mrkdwn_in: ["text","fields","pretext"],
+              unfurl_links: true
+          }
+        ]
+      }
     end
 
     def transform_issue_status_changed(mash)


### PR DESCRIPTION
Fixes https://github.com/huboard/huboard/issues/641. We're already trying to guard against this, but we're not using `before_perform` correctly. Beyond that, we don't actually want to prevent the job from firing altogether because that would also prevent card relocations from publishing to the client.