### PR TITLE
Fixes the broken 'issueUnlabeled' event

### DIFF
--- a/ember-app/app/mixins/subscriptions/board.js
+++ b/ember-app/app/mixins/subscriptions/board.js
@@ -129,7 +129,7 @@ var BoardSubscriptionMixin = Ember.Mixin.create({
       var copy = `${message.actor.login} changed #${message.issue.number}'s labels`;
       this.get("flashMessages").info(copy);
     }, {time: 5000}),
-    issueUnlabled: sortedQueue(function(message) {
+    issueUnlabeled: sortedQueue(function(message) {
       var timeA = Date.parse(message.issue.updated_at);
       var timeB = Date.parse(this.get("issue.data.updated_at"));
       if(timeA > timeB){


### PR DESCRIPTION
Due to a type, `issue_unlabeled` events were failing on the client. Furthermore the exceptions generated by the failure prevents all further events to dispatch until refresh :( 

All of our users who have struggled through this deserve an apology. I am so sorry!

Additional bug I found: 
- The toast will never work in the current configuration (the timestamp check should always fail), I will address this in a future PR