### PR TITLE
Fixes client-side closed issue events causing exceptions after rails upgrade

### DIFF
--- a/app/controllers/api/issues_controller.rb
+++ b/app/controllers/api/issues_controller.rb
@@ -99,7 +99,7 @@ module Api
         message = {
           :issue => @issue,
           'action_controller.params' => {'correlationId' => params['correlationId']},
-          :current_user => current_user.attribs || {}
+          'current_user' => current_user.attribs || {}
         }
         generate_issue_event(data['state'], message)
       end


### PR DESCRIPTION
The previous rails upgrade (https://github.com/huboard/huboard-web/pull/237) changed the way ActiveJob serializes hashes, this cause an unexpected breakage in this job causing the actor to be null. 

Closes https://github.com/huboard/huboard/issues/647