### PR TITLE
WIP: Replace Milestone Breadcrumb

### DIFF
--- a/ember-app/app/templates/components/hb-milestone-card.hbs
+++ b/ember-app/app/templates/components/hb-milestone-card.hbs
@@ -9,15 +9,6 @@
     </div>
   </div>
 
-  <div class="flex-crumbs">
-    {{hb-selected-column
-      columns=taskColumns
-      issue=issue
-      previewOnly=true
-    }}
-  </div>
-
-
   <div class="card-labels">
       {{#each label in cardLabels }}
         <div class="card-label-wrapper"> 


### PR DESCRIPTION
Closes huboard/huboard#650
Closes https://github.com/huboard/huboard/issues/586 

Mostly opening this PR to see how breadcrumb removal impacts switch to Milestones view.

<!---
@huboard:{"order":62.25,"milestone_order":277,"custom_state":""}
-->
