### PR TITLE
Truncate commit messages beyond first newline

### DIFF
--- a/ember-app/app/templates/issue/reference.hbs
+++ b/ember-app/app/templates/issue/reference.hbs
@@ -10,7 +10,11 @@
       </a> 
      <span class="commit-message"> 
        <span class="commit-link">-o-</span> {{hb-avatar user=model.actor width=16 height=16 }} 
-       {{view.message}}
+       {{#if view.message}}
+         {{view.message}}
+       {{else}}
+         <span class="empty">No commit message</span>
+       {{/if}}
      </span> 
     </div>
 {{else}}

--- a/ember-app/app/templates/issue/reference.hbs
+++ b/ember-app/app/templates/issue/reference.hbs
@@ -10,11 +10,10 @@
       </a> 
      <span class="commit-message"> 
        <span class="commit-link">-o-</span> {{hb-avatar user=model.actor width=16 height=16 }} 
-       {{#if view.message}}
-         {{view.message}}
-       {{else}}
+       {{view.message}}
+       {{#unless view.message}}
          <span class="empty">No commit message</span>
-       {{/if}}
+       {{/unless}}
      </span> 
     </div>
 {{else}}

--- a/ember-app/app/views/issue/reference.js
+++ b/ember-app/app/views/issue/reference.js
@@ -8,7 +8,14 @@ var IssueReferenceView = Ember.View.extend({
   commit: null,
   commitUrl: Ember.computed.alias("commit.html_url"),
   message: function(){
-    var message = emojiParser.parse(this.get("commit.commit.message"));
+    var message = this.get("commit.commit.message") || "",
+        newline = message.indexOf('\n');
+
+    if (newline !== -1) {
+      message = message.substring(0, newline);
+    }
+
+    message = emojiParser.parse(message);
     return message.htmlSafe();
   }.property("commit.commit.message"),
   shortSha: function(){

--- a/ember-app/app/views/issue/reference.js
+++ b/ember-app/app/views/issue/reference.js
@@ -11,9 +11,12 @@ var IssueReferenceView = Ember.View.extend({
     var message = this.get("commit.commit.message") || "",
         newline = message.indexOf('\n');
 
-    if (newline !== -1) {
+    if (newline > 0) {
       message = message.substring(0, newline);
     }
+    message = message.trim();
+
+    if (!message) { return ""; }
 
     message = emojiParser.parse(message);
     return message.htmlSafe();

--- a/ember-app/app/views/issue/reference.js
+++ b/ember-app/app/views/issue/reference.js
@@ -18,6 +18,7 @@ var IssueReferenceView = Ember.View.extend({
 
     if (!message) { return ""; }
 
+    message = Ember.Handlebars.Utils.escapeExpression(message)
     message = emojiParser.parse(message);
     return message.htmlSafe();
   }.property("commit.commit.message"),


### PR DESCRIPTION
Fixes #138 

Note that this truncation behavior does not align with how `git log --oneline` parses titles. See [discussion](https://github.com/huboard/huboard-web/issues/138#issuecomment-212650005) for rationale.