### PR TITLE
Add /dashboard route

### DIFF
--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -8,12 +8,12 @@ class LoginController < ApplicationController
     github_authenticate! :default
     @user = gh.user
     @emails = @user.emails.all
-    redirect_to params[:redirect_to] || "/"
+    redirect_to params[:redirect_to] || "/dashboard"
   end
   def private
     github_authenticate! :private
     @user = gh.user
     @emails = @user.emails.all
-    redirect_to params[:redirect_to] || "/"
+    redirect_to params[:redirect_to] || "/dashboard"
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
          <div class="navbar-inner">
            <div class="container">
             <ul class="nav breadcrumbs">
-              <li><a href="/" class="home"><i class="ui-icon ui-icon-menu"></i></a></li>
+              <li><a href="/dashboard" class="home"><i class="ui-icon ui-icon-menu"></i></a></li>
               <%= content_for :breadcrumb %>
             </ul>
              <ul class="nav pull-right">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,8 @@ Rails.application.routes.draw do
   get 'login/public' => 'login#public'
   get 'login/private' => 'login#private'
 
+  get '/dashboard' => 'dashboard#index'
+
   get '/repositories/private/:user' => 'dashboard#private', as: 'repositories_private'
 
   get '/repositories/public/:user' => 'dashboard#public', as: 'repositories_public'

--- a/ember-app/app/templates/application.hbs
+++ b/ember-app/app/templates/application.hbs
@@ -2,7 +2,7 @@
  <div class="navbar-inner">
    <div class="container-fluid">
     <ul class="nav breadcrumbs">
-      <li><a href="/" class="home"><i class="ui-icon ui-icon-menu"></i></a></li>
+      <li><a href="/dashboard" class="home"><i class="ui-icon ui-icon-menu"></i></a></li>
       <li><a href="{{model.userUrl}}">{{model.repo.owner.login}}</a></li>
       <li><a href="{{model.repoUrl}}">{{model.repo.name}}</a></li>
       <li>


### PR DESCRIPTION
In support of https://github.com/huboard/huboard-web/pull/285, here's most of #229:

☑ Add /dashboard route for the dashboard.
☒ Remove the logic to show the dashboard on / if you're authenticated.
☑ Make /login redirect to /dashboard if you're already authenticated.

We can kick the `/` change down the road... I'm not 100% sold on that.

<!---
@huboard:{"order":254.5625,"milestone_order":287,"custom_state":""}
-->
