### PR TITLE
Differentiate new PRs from issues in notifications

### DIFF
--- a/app/controllers/api/webhooks_controller.rb
+++ b/app/controllers/api/webhooks_controller.rb
@@ -31,6 +31,7 @@ module Api
       payload[:pull_request].extend(Huboard::Issues::Card).merge!(repo)
 
       message = HashWithIndifferentAccess.new(
+        :pull_request => true,
         :issue => payload[:pull_request],
         :label => payload[:label],
         "action_controller.params" => {},

--- a/app/jobs/api/issues_open_issue_job.rb
+++ b/app/jobs/api/issues_open_issue_job.rb
@@ -6,6 +6,7 @@ module Api
 
     def payload(params)
       {
+        pull_request: params[:pull_request],
         issue: params[:issue]
       }
     end

--- a/lib/hu_board/services/hip_chat.rb
+++ b/lib/hu_board/services/hip_chat.rb
@@ -76,9 +76,10 @@ module HuBoard
     end
 
     def transform_issue_opened(mash)
+      type = mash.payload.pull_request.nil? ? "issue" : "pull request"
       {
         color: "purple",
-        message: "#{avatar(mash)} <a href='#{URI.join(github_url,mash.meta.user.login)}'> #{mash.meta.user.login} </a> opened a new issue <a href='#{mash.payload.issue.html_url}'>#{mash.meta.repo_full_name}##{mash.payload.issue.number}</a> <br><b>#{mash.payload.issue.title}</b><br>#{mash.payload.issue.body}",
+        message: "#{avatar(mash)} <a href='#{URI.join(github_url,mash.meta.user.login)}'> #{mash.meta.user.login} </a> opened a new #{type} <a href='#{mash.payload.issue.html_url}'>#{mash.meta.repo_full_name}##{mash.payload.issue.number}</a> <br><b>#{mash.payload.issue.title}</b><br>#{mash.payload.issue.body}",
         notify: true,
         message_format: 'html'
       }

--- a/lib/hu_board/services/slack.rb
+++ b/lib/hu_board/services/slack.rb
@@ -127,13 +127,14 @@ module HuBoard
     end
 
     def transform_issue_opened(mash)
+      type = mash.payload.pull_request.nil? ? "issue" : "pull request"
       {
         username: "#{mash.meta.user.login} via HuBoard",
         icon_url: avatar_url(mash),
         attachments: [
           {
-            fallback: "<#{URI.join(github_url,mash.meta.user.login)}|@#{mash.meta.user.login}> opened a new issue <#{mash.payload.issue.html_url}|#{mash.meta.repo_full_name}##{mash.payload.issue.number}>",
-            pretext: "<#{URI.join(github_url,mash.meta.user.login)}|@#{mash.meta.user.login}> opened a new issue <#{mash.payload.issue.html_url}|#{mash.meta.repo_full_name}##{mash.payload.issue.number}>",
+            fallback: "<#{URI.join(github_url,mash.meta.user.login)}|@#{mash.meta.user.login}> opened a new #{type} <#{mash.payload.issue.html_url}|#{mash.meta.repo_full_name}##{mash.payload.issue.number}>",
+            pretext: "<#{URI.join(github_url,mash.meta.user.login)}|@#{mash.meta.user.login}> opened a new #{type} <#{mash.payload.issue.html_url}|#{mash.meta.repo_full_name}##{mash.payload.issue.number}>",
             fields: [
               {title: "#{mash.payload.issue.title}", value: "#{mash.payload.issue.body_text.split("\n").take(3).join("\n")}", short: false},
             ],


### PR DESCRIPTION
Follow-up from #255

Fixes this:
<img width="330" alt="slack_2016-05-13_15-03-16" src="https://cloud.githubusercontent.com/assets/133987/15260323/d7d82bbc-191b-11e6-89d0-872a05f319e4.png">
