### PR TITLE
Fix `gem install mailcatcher`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -497,4 +497,4 @@ DEPENDENCIES
   wkhtmltopdf-heroku
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/Puppetfile
+++ b/Puppetfile
@@ -12,4 +12,4 @@ mod 'saz/memcached'
 mod 'thomasvandoren/redis'
 mod 'willdurand/nodejs'
 
-mod 'jlondon/wkhtmltox', '1.0.9'
+mod 'jlondon/wkhtmltox', '1.0.11'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -2,7 +2,7 @@ FORGE
   remote: https://forgeapi.puppetlabs.com
   specs:
     alup-rbenv (1.2.0)
-    jlondon-wkhtmltox (1.0.9)
+    jlondon-wkhtmltox (1.0.11)
       maestrodev-wget (>= 1.5.0)
       puppetlabs-stdlib (>= 0)
     maestrodev-wget (1.5.7)
@@ -29,7 +29,7 @@ FORGE
 
 DEPENDENCIES
   alup-rbenv (>= 0)
-  jlondon-wkhtmltox (= 1.0.9)
+  jlondon-wkhtmltox (= 1.0.11)
   puppetlabs-apt (>= 0)
   puppetlabs-postgresql (>= 0)
   puppetlabs-stdlib (= 4.2.0)

--- a/puppet/manifests/base.pp
+++ b/puppet/manifests/base.pp
@@ -13,6 +13,10 @@ package {
   class { 'ruby_install': 
     ruby_version => "2.2.1",
   } ->
+  exec { 'apt-install ruby-dev':
+    path    => ["/bin", "/usr/bin", "/sbin"],
+    command => "apt-get install ruby-dev -y"
+  } ->
   exec { 'mail-catcher':
     path    => ["/bin", "/usr/bin"],
     command => 'gem install mailcatcher'

--- a/puppet/manifests/base.pp
+++ b/puppet/manifests/base.pp
@@ -17,9 +17,9 @@ package {
     path    => ["/bin", "/usr/bin", "/sbin"],
     command => "apt-get install ruby-dev -y"
   } ->
-  exec { 'mail-catcher':
-    path    => ["/bin", "/usr/bin"],
-    command => 'gem install mailcatcher'
+  rbenv::gem { 'mailcatcher':
+    ruby => '2.2.1',
+    user => 'vagrant'
   }
 
   class { 'wkhtmltox':

--- a/puppet/manifests/base.pp
+++ b/puppet/manifests/base.pp
@@ -14,6 +14,7 @@ package {
     ruby_version => "2.2.1",
   } ->
   exec { 'mail-catcher':
+    path    => ["/bin", "/usr/bin"],
     command => 'gem install mailcatcher'
   }
 


### PR DESCRIPTION
`vagrant provision` is failing for me since https://github.com/huboard/huboard-web/commit/b68856ad31adba356adecf476c3682ce0ad2d922.

### Error 1

```
==> default: Error: Validation of Exec[mail-catcher] failed: 'gem install mailcatcher' is not qualified and no path was specified. Please qualify the command or specify a path. at /tmp/vagrant-puppet/manifests-846018e2aa141a5eb79a64b4015fc5f3/base.pp:18
```

* [x] Fixed with `path`.

### Error 2

```
==> default: Notice: /Stage[main]/Main/Exec[mail-catcher]/returns: Building native extensions.  This could take a while...
==> default: Notice: /Stage[main]/Main/Exec[mail-catcher]/returns: ERROR:  Error installing mailcatcher:
==> default: Notice: /Stage[main]/Main/Exec[mail-catcher]/returns: 	ERROR: Failed to build gem native extension.
==> default: Notice: /Stage[main]/Main/Exec[mail-catcher]/returns: 
==> default: Notice: /Stage[main]/Main/Exec[mail-catcher]/returns:         /usr/bin/ruby1.9.1 extconf.rb
==> default: Notice: /Stage[main]/Main/Exec[mail-catcher]/returns: /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- mkmf (LoadError)
==> default: Notice: /Stage[main]/Main/Exec[mail-catcher]/returns: 	from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
==> default: Notice: /Stage[main]/Main/Exec[mail-catcher]/returns: 	from extconf.rb:1:in `<main>'
==> default: Notice: /Stage[main]/Main/Exec[mail-catcher]/returns: 
==> default: Notice: /Stage[main]/Main/Exec[mail-catcher]/returns: 
==> default: Notice: /Stage[main]/Main/Exec[mail-catcher]/returns: Gem files will remain installed in /var/lib/gems/1.9.1/gems/json-1.8.3 for inspection.
==> default: Notice: /Stage[main]/Main/Exec[mail-catcher]/returns: Results logged to /var/lib/gems/1.9.1/gems/json-1.8.3/ext/json/ext/generator/gem_make.out
```

* [x] Fixed with `apt-get install ruby-dev`.

### Error 3

```
==> default: Notice: /Stage[main]/Main/Exec[mail-catcher]/returns: ERROR:  Error installing mailcatcher:
==> default: Notice: /Stage[main]/Main/Exec[mail-catcher]/returns:      mime-types-data requires Ruby version >= 2.0.
```

* [x] Fix = ?

<!---
@huboard:{"order":261.078307830261,"milestone_order":300,"custom_state":""}
-->
