### PR TITLE
Chains the card extension to fix failed payload merges

### DIFF
--- a/lib/bridge/github/issues.rb
+++ b/lib/bridge/github/issues.rb
@@ -74,9 +74,8 @@ class Huboard
 
       issue = gh.issues(number) do |request|
         request.headers["Accept"] = "application/vnd.github.squirrel-girl-preview.full+json"
-      end
+      end.extend(Card).merge!(repo: {owner: {login: user}, name: repo, full_name: "#{user}/#{repo}" })
 
-      issue.extend(Card).merge!(repo: {owner: {login: user}, name: repo, full_name: "#{user}/#{repo}" })
       issue[:repo][:is_collaborator] = gh['permissions'] ? gh['permissions']['push'] : nil
       issue.attach_client connection_factory
       issue


### PR DESCRIPTION
I have no idea why this works, but the `Ghee::ResourceProxy` will not properly extend the object unless the calls are chained together. This breakage started right here: https://github.com/huboard/huboard-web/pull/301/commits/e359da75c3e13cf166d09a3af4b66b1cf551fa06#diff-55d956adac5de9504d394fc2fa4b22dcR75