### PR TITLE
Fix rare MAX/MIN overflows in issue ordering

### DIFF
--- a/ember-app/app/components/columns/hb-column.js
+++ b/ember-app/app/components/columns/hb-column.js
@@ -45,9 +45,11 @@ var HbColumnComponent = Ember.Component.extend(SortableMixin, {
       return a.data._data.milestone_order - b.data._data.milestone_order;
     });
     if(issues.length){
+      var top_issue = issues.get("firstObject.data");
+      var top_milestone_issue = milestone_issues.get("firstObject.data");
       return {
-        order: issues.get("firstObject.data._data.order") / 2,
-        milestone_order: milestone_issues.get("firstObject.data._data.milestone_order") / 2
+        order: this.cardMover.moveToTop({}, top_issue),
+        milestone_order: this.cardMover.moveToTop({}, top_milestone_issue)
       };
     } else {
       return {};

--- a/ember-app/app/components/columns/hb-column.js
+++ b/ember-app/app/components/columns/hb-column.js
@@ -48,8 +48,8 @@ var HbColumnComponent = Ember.Component.extend(SortableMixin, {
       var top_issue = issues.get("firstObject.data");
       var top_milestone_issue = milestone_issues.get("firstObject.data");
       return {
-        order: this.cardMover.moveToTop({}, top_issue),
-        milestone_order: this.cardMover.moveToTop({}, top_milestone_issue)
+        order: this.cardMover.moveToTop(top_issue),
+        milestone_order: this.cardMover.moveToTop(top_milestone_issue)
       };
     } else {
       return {};

--- a/ember-app/app/components/columns/hb-milestone.js
+++ b/ember-app/app/components/columns/hb-milestone.js
@@ -80,14 +80,15 @@ var HbMilestoneComponent = HbColumn.extend(
         return a.data._data.order - b.data._data.order;
       }).get("firstObject");
     if(issues.length){
-      var order = { milestone_order: issues.get("firstObject.data._data.milestone_order") / 2};
+      var milestone_order = this.cardMover.moveToTop(issues.get("firstObject.data"));
+      var order = { milestone_order: milestone_order};
       if(first){
-        order.order = first.data._data.order / 2;
+        order.order = this.cardMover.moveToTop(first.data);
       }
       return order;
     } else {
       if(first){
-        return { order: first.data._data.order / 2 };
+        return { order: this.cardMover.moveToTop(first.data) };
       }
       return {};
     }

--- a/ember-app/app/mixins/cards/card-move.js
+++ b/ember-app/app/mixins/cards/card-move.js
@@ -23,6 +23,7 @@ var CardMoveMixin = Ember.Mixin.create({
     moveToTop: function(issue_below){
       var below_order = issue_below._data[this.get("orderKey")]
       var order = below_order / this.orderMultiplier;
+      if(order <= 0){ order = issue_below.get('data.id') * this.minThreshold; }
       while(order < this.minThreshold){ order *= 10; }
 
       return order;
@@ -30,6 +31,8 @@ var CardMoveMixin = Ember.Mixin.create({
     moveToBottom: function(issue_above){
       var above_order = issue_above._data[this.get("orderKey")];
       var order = above_order * this.orderMultiplier;
+
+      if(order === Infinity){ order = issue_above.get('data.id') / this.maxThreshold; }
       while(order > this.maxThreshold){ order /= 10; }
 
       return order;

--- a/ember-app/app/mixins/cards/card-move.js
+++ b/ember-app/app/mixins/cards/card-move.js
@@ -23,6 +23,7 @@ var CardMoveMixin = Ember.Mixin.create({
     moveToTop: function(issue_below){
       var below_order = issue_below._data[this.get("orderKey")];
       var order = below_order / this.orderMultiplier;
+
       if(order <= 0){ order = issue_below.get('data.id') * this.minThreshold; }
       while(order < this.minThreshold){ order *= 10; }
 

--- a/ember-app/app/mixins/cards/card-move.js
+++ b/ember-app/app/mixins/cards/card-move.js
@@ -21,7 +21,7 @@ var CardMoveMixin = Ember.Mixin.create({
       return (above_order + below_order) / 2;
     },
     moveToTop: function(issue_below){
-      var below_order = issue_below._data[this.get("orderKey")]
+      var below_order = issue_below._data[this.get("orderKey")];
       var order = below_order / this.orderMultiplier;
       if(order <= 0){ order = issue_below.get('data.id') * this.minThreshold; }
       while(order < this.minThreshold){ order *= 10; }
@@ -32,7 +32,7 @@ var CardMoveMixin = Ember.Mixin.create({
       var above_order = issue_above._data[this.get("orderKey")];
       var order = above_order * this.orderMultiplier;
 
-      if(order === Infinity){ order = issue_above.get('data.id') / this.maxThreshold; }
+      if(order === Infinity){ order = this.maxThreshold / 1e10 * issue_above.get('data.id'); }
       while(order > this.maxThreshold){ order /= 10; }
 
       return order;

--- a/ember-app/app/mixins/cards/card-move.js
+++ b/ember-app/app/mixins/cards/card-move.js
@@ -21,10 +21,15 @@ var CardMoveMixin = Ember.Mixin.create({
       return (above_order + below_order) / 2;
     },
     moveToTop: function(issue, issue_below){
-      return (issue_below._data[this.get("orderKey")]) / 2;
+      var order = (issue_below._data[this.get("orderKey")]) / this.orderMultiplier;
+      if(order < (this.orderMultiplier * Number.MIN_VALUE)){
+        return issue_below.get('data.id') * Number.MIN_VALUE;
+      }
+
+      return order;
     },
     moveToBottom: function(issue, issue_above){
-      return issue_above._data[this.get("orderKey")] + 1;
+      return issue_above._data[this.get("orderKey")] * this.orderMultiplier;
     },
     findCard: function(element, column){
       return column.get("cards").find(function(card){
@@ -59,7 +64,8 @@ var CardMoveMixin = Ember.Mixin.create({
       //Adjust based on issue dragging up or down
       if(column_changed){ return 0; }
       return index >= this.data.originIndex ? 1 : 0;
-    }
+    },
+    orderMultiplier: 1.0001
   })
 });
 

--- a/ember-app/app/mixins/cards/card-move.js
+++ b/ember-app/app/mixins/cards/card-move.js
@@ -11,8 +11,8 @@ var CardMoveMixin = Ember.Mixin.create({
     calculateIssueOrder: function(issue_above, issue_below){
       var issue = this.data.card.get("issue.data");
       if(!issue_above && !issue_below){return issue._data.order; }
-      if(!issue_above){ return this.moveToTop(issue, issue_below); }
-      if(!issue_below){ return this.moveToBottom(issue, issue_above); }
+      if(!issue_above){ return this.moveToTop(issue_below); }
+      if(!issue_below){ return this.moveToBottom(issue_above); }
       return this.move(issue, issue_above, issue_below);
     },
     move: function(issue, issue_above, issue_below){
@@ -20,16 +20,19 @@ var CardMoveMixin = Ember.Mixin.create({
       var below_order = issue_below._data[this.get("orderKey")];
       return (above_order + below_order) / 2;
     },
-    moveToTop: function(issue, issue_below){
-      var order = (issue_below._data[this.get("orderKey")]) / this.orderMultiplier;
-      if(order < (this.orderMultiplier * Number.MIN_VALUE)){
-        return issue_below.get('data.id') * Number.MIN_VALUE;
-      }
+    moveToTop: function(issue_below){
+      var below_order = issue_below._data[this.get("orderKey")]
+      var order = below_order / this.orderMultiplier;
+      while(order < this.minThreshold){ order *= 10; }
 
       return order;
     },
-    moveToBottom: function(issue, issue_above){
-      return issue_above._data[this.get("orderKey")] * this.orderMultiplier;
+    moveToBottom: function(issue_above){
+      var above_order = issue_above._data[this.get("orderKey")];
+      var order = above_order * this.orderMultiplier;
+      while(order > this.maxThreshold){ order /= 10; }
+
+      return order;
     },
     findCard: function(element, column){
       return column.get("cards").find(function(card){
@@ -65,7 +68,9 @@ var CardMoveMixin = Ember.Mixin.create({
       if(column_changed){ return 0; }
       return index >= this.data.originIndex ? 1 : 0;
     },
-    orderMultiplier: 1.0001
+    orderMultiplier: 1.0001,
+    minThreshold: 1e-319,
+    maxThreshold: 1e307
   })
 });
 

--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -189,11 +189,12 @@ var Issue = Model.extend({
     }.bind(this), "json");
   },
   maxMinOrderFix: function(){
-    if(this.get('order') < (Number.MIN_VALUE * 1e4)){
-      var adjusted_order = (this.get('data.number') * 1e4) * Number.MIN_VALUE;
-      this.set('order', adjusted_order);
-    }
-  }.observes('order').on('init')
+    var order = this.get('order');
+    while(order < 1e-319){ order *= 10; }
+    while(order > 1e307){ order /= 10; }
+
+    this.set('order', order);
+  }.on('init')
 });
 
 export default Issue;

--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -188,14 +188,21 @@ var Issue = Model.extend({
       return this;
     }.bind(this), "json");
   },
-  maxMinOrderFix: function(){
-    var order = this.get('order');
+  runMaxMinOrderFix: function(){
+    var order = this.maxMinOrderFix(this.get('order'));
+    var milestone_order = this.maxMinOrderFix(this.get('milestone_order'));
+
+    if(order != this.get('order')){this.set('order', order)};
+    if(milestone_order != this.get('milestone_order')){ 
+      this.set('milestone_order', milestone_order)
+    };
+  }.on('init'),
+  maxMinOrderFix: function(order){
     if(order <= 0 || order === Infinity){ order = this.get('data.id') * Number.MIN_VALUE }
     while(order < 1e-319){ order *= 10; }
     while(order > 1e307){ order /= 10; }
-
-    this.set('order', order);
-  }.on('init')
+    return order;
+  }
 });
 
 export default Issue;

--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -190,6 +190,7 @@ var Issue = Model.extend({
   },
   maxMinOrderFix: function(){
     var order = this.get('order');
+    if(order <= 0 || order === Infinity){ order = this.get('data.id') * Number.MIN_VALUE }
     while(order < 1e-319){ order *= 10; }
     while(order > 1e307){ order /= 10; }
 

--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -187,7 +187,13 @@ var Issue = Model.extend({
       this.set("data.body_html", response.body_html);
       return this;
     }.bind(this), "json");
-  }
+  },
+  maxMinOrderFix: function(){
+    if(this.get('order') < (Number.MIN_VALUE * 1e4)){
+      var adjusted_order = (this.get('data.number') * 1e4) * Number.MIN_VALUE;
+      this.set('order', adjusted_order);
+    }
+  }.observes('order').on('init')
 });
 
 export default Issue;

--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -190,15 +190,17 @@ var Issue = Model.extend({
   },
   runMaxMinOrderFix: function(){
     var order = this.maxMinOrderFix(this.get('order'));
-    var milestone_order = this.maxMinOrderFix(this.get('milestone_order'));
+    var milestone_order = this.maxMinOrderFix(this.data._data.milestone_order);
 
-    if(order != this.get('order')){this.set('order', order)};
-    if(milestone_order != this.get('milestone_order')){ 
-      this.set('milestone_order', milestone_order)
-    };
+    if(order !== this.get('order')){
+      this.set('order', order);
+    }
+    if(milestone_order !== this.data._data.milestone_order){
+      this.data._data.milestone_order = milestone_order;
+    }
   }.on('init'),
   maxMinOrderFix: function(order){
-    if(order <= 0 || order === Infinity){ order = this.get('data.id') * Number.MIN_VALUE }
+    if(order <= 0 || order === Infinity){ order = this.get('data.id') * Number.MIN_VALUE; }
     while(order < 1e-319){ order *= 10; }
     while(order > 1e307){ order /= 10; }
     return order;

--- a/ember-app/tests/unit/mixins/cards/card-move-test.js
+++ b/ember-app/tests/unit/mixins/cards/card-move-test.js
@@ -10,13 +10,13 @@ var sut;
 
 function createIssueData(){
   return Ember.Object.create({
-    _data: { order: 2.5 },
+    _data: { test_order: 2.5 },
     data: Ember.Object.create({ id: 123, title: 'test' })
   });
 }
 
 function minMaxZeroOrderFixAlgorithm(issue){
-  var order = issue._data.order;
+  var order = issue._data.test_order;
   while(order < 1e-319){ order *= 10; }
   while(order > 1e307){ order /= 10; }
 
@@ -32,50 +32,50 @@ moduleFor('mixin:cards/card-move', 'CardMoveMixin', {
 
 test('move the issue to the top', function(assert){
   var cardMover = sut.cardMover;
-  cardMover.set('orderKey', 'order');
+  cardMover.set('orderKey', 'test_order');
 
   //Moves issue to the top
   var issueBelow = createIssueData();
   var result = cardMover.moveToTop(issueBelow);
-  assert.ok(result < issueBelow._data.order, 'The new order is less than the issue below');
+  assert.ok(result < issueBelow._data.test_order, 'The new order is less than the issue below');
 
   //Moves issue to the top when order has been adjusted for MIN_VALUE
   issueBelow = createIssueData();
-  issueBelow._data.order = 5e-324;
-  issueBelow._data.order = minMaxZeroOrderFixAlgorithm(issueBelow);
+  issueBelow._data.test_order = Number.MIN_VALUE;
+  issueBelow._data.test_order = minMaxZeroOrderFixAlgorithm(issueBelow);
 
   result = cardMover.moveToTop(issueBelow);
-  assert.ok(result < issueBelow._data.order, 'The new order is less than the issue below');
+  assert.ok(result < issueBelow._data.test_order, 'The new order is less than the issue below');
 
-  //If issue move is impossible give it a value below the minThreshold
+  //If issue move is impossible give it a value greater than the minThreshold
   issueBelow = createIssueData();
-  issueBelow._data.order = 1e-323;
+  issueBelow._data.test_order = 1e-323;
 
   result = cardMover.moveToTop(issueBelow);
-  assert.ok(result > cardMover.minThreshold, 'The new order is less than the issue below');
+  assert.ok(result > cardMover.minThreshold, 'The new order is greater than the minThreshold');
 });
 
 test('move the issue to the bottom', function(assert){
   var cardMover = sut.cardMover;
-  cardMover.set('orderKey', 'order');
+  cardMover.set('orderKey', 'test_order');
 
   //Moves issue to the bottom 
   var issueAbove = createIssueData();
   var result = cardMover.moveToBottom(issueAbove);
-  assert.ok(result > issueAbove._data.order, 'The new order is greater than the issue above');
+  assert.ok(result > issueAbove._data.test_order, 'The new order is greater than the issue above');
 
   //Moves issue to the bottom when order has been adjusted for MAX_VALUE
   issueAbove = createIssueData();
-  issueAbove._data.order = Number.MAX_VALUE;
-  issueAbove._data.order = minMaxZeroOrderFixAlgorithm(issueAbove);
+  issueAbove._data.test_order = Number.MAX_VALUE;
+  issueAbove._data.test_order = minMaxZeroOrderFixAlgorithm(issueAbove);
 
   result = cardMover.moveToBottom(issueAbove);
-  assert.ok(result > issueAbove._data.order, 'The adjusted order is greater than the issue below');
+  assert.ok(result > issueAbove._data.test_order, 'The adjusted order is greater than the issue above');
 
-  //If issue move is impossible give it a value above the maxThreshold
+  //If issue move is impossible give it a value below the maxThreshold
   issueAbove = createIssueData();
-  issueAbove._data.order = 1.797692738796007e+308;
+  issueAbove._data.test_order = 1.797692738796007e+308;
 
-  result = cardMover.moveToTop(issueAbove);
-  assert.ok(result > cardMover.minThreshold, 'The new order is less than the issue below');
+  result = cardMover.moveToBottom(issueAbove);
+  assert.ok(result < cardMover.maxThreshold, 'The new order is less than the maxThreshold');
 });

--- a/ember-app/tests/unit/mixins/cards/card-move-test.js
+++ b/ember-app/tests/unit/mixins/cards/card-move-test.js
@@ -1,0 +1,81 @@
+import Ember from 'ember';
+import CardMoveMixin from 'app/mixins/cards/card-move';
+
+import {
+  moduleFor,
+  test
+} from 'ember-qunit';
+
+var sut;
+
+function createIssueData(){
+  return Ember.Object.create({
+    _data: { order: 2.5 },
+    data: Ember.Object.create({ id: 123, title: 'test' })
+  });
+}
+
+function minMaxZeroOrderFixAlgorithm(issue){
+  var order = issue._data.order;
+  while(order < 1e-319){ order *= 10; }
+  while(order > 1e307){ order /= 10; }
+
+  return order;
+}
+
+moduleFor('mixin:cards/card-move', 'CardMoveMixin', {
+  setup: function(){
+    sut = Ember.Object.
+      createWithMixins(CardMoveMixin, {});
+  }
+});
+
+test('move the issue to the top', function(assert){
+  var cardMover = sut.cardMover;
+  cardMover.set('orderKey', 'order');
+
+  //Moves issue to the top
+  var issueBelow = createIssueData();
+  var result = cardMover.moveToTop(issueBelow);
+  assert.ok(result < issueBelow._data.order, 'The new order is less than the issue below');
+
+  //Moves issue to the top when order has been adjusted for MIN_VALUE
+  issueBelow = createIssueData();
+  issueBelow._data.order = 5e-324;
+  issueBelow._data.order = minMaxZeroOrderFixAlgorithm(issueBelow);
+
+  result = cardMover.moveToTop(issueBelow);
+  assert.ok(result < issueBelow._data.order, 'The new order is less than the issue below');
+
+  //If issue move is impossible give it a value below the minThreshold
+  issueBelow = createIssueData();
+  issueBelow._data.order = 1e-323;
+
+  result = cardMover.moveToTop(issueBelow);
+  assert.ok(result > cardMover.minThreshold, 'The new order is less than the issue below');
+});
+
+test('move the issue to the bottom', function(assert){
+  var cardMover = sut.cardMover;
+  cardMover.set('orderKey', 'order');
+
+  //Moves issue to the bottom 
+  var issueAbove = createIssueData();
+  var result = cardMover.moveToBottom(issueAbove);
+  assert.ok(result > issueAbove._data.order, 'The new order is greater than the issue above');
+
+  //Moves issue to the bottom when order has been adjusted for MAX_VALUE
+  issueAbove = createIssueData();
+  issueAbove._data.order = Number.MAX_VALUE;
+  issueAbove._data.order = minMaxZeroOrderFixAlgorithm(issueAbove);
+
+  result = cardMover.moveToBottom(issueAbove);
+  assert.ok(result > issueAbove._data.order, 'The adjusted order is greater than the issue below');
+
+  //If issue move is impossible give it a value above the maxThreshold
+  issueAbove = createIssueData();
+  issueAbove._data.order = 1.797692738796007e+308;
+
+  result = cardMover.moveToTop(issueAbove);
+  assert.ok(result > cardMover.minThreshold, 'The new order is less than the issue below');
+});

--- a/lib/bridge/github/issues.rb
+++ b/lib/bridge/github/issues.rb
@@ -244,12 +244,14 @@ class Huboard
             if !data["order"].is_a?(Numeric) || data["order"] <= 0
               data["order"] = self['id'] * zero_adjustment
               data["zero_fix"] = true
+              self['body'] = self['body'].to_s.gsub /@huboard:.*/, "@huboard:#{MultiJson.dump(data)}"
             end
 
             data["milestone_order"] = self['number'] unless data["milestone_order"]
             if !data["milestone_order"].is_a?(Numeric) || data["milestone_order"] <= 0
               data["milestone_order"] = self['id'] * zero_adjustment
               data["zero_fix"] = true
+              self['body'] = self['body'].to_s.gsub /@huboard:.*/, "@huboard:#{MultiJson.dump(data)}"
             end
 
             return data


### PR DESCRIPTION
As reported by a couple users, on rare occasion newly created cards can be bumped part-ways down the column, and cards moves can occasionally cause strange behavior (it will jump to somewhere else on drag)

It turns out the cause of these troubles relate to javascripts `Number.MIN_VALUE/MAX_VALUE` and how HuBoard has calculated moves to persist orders over the years. When an order reaches to point where the MIN/MAX is overwhelmed, the card is no longer moveable, and moves around that card became impossible for JS to compute. 

This PR addresses this in a couple of ways:

- Any current cards on a board that are over/under  `minThreshold: 1e-319` || `maxThreshold: 1e307`  will be algorithmically scaled down to more digestable orders (unfortunately this _will_ shuffle currently affected cards)

- The increments for moving cards up and down a column have been drastically reduced, which should prevent this from ever happening again in the future. 

Shoutout to @dahlbyk who helped me greatly in getting the Maths right on this