### PR TITLE
Prevents QP's from polluting others with matching name

### DIFF
--- a/ember-app/app/services/filter_groups/member.js
+++ b/ember-app/app/services/filter_groups/member.js
@@ -19,6 +19,7 @@ var MemberFilters = Ember.Service.extend({
          name: a.login,
          avatar : a,
          mode: 0,
+         queryParam: 'member',
          condition: function (i) {
             return i.data.assignee && i.data.assignee.login === a.login;
          }

--- a/ember-app/app/services/filter_groups/member.js
+++ b/ember-app/app/services/filter_groups/member.js
@@ -19,7 +19,7 @@ var MemberFilters = Ember.Service.extend({
          name: a.login,
          avatar : a,
          mode: 0,
-         queryParam: 'member',
+         queryParam: 'assignee',
          condition: function (i) {
             return i.data.assignee && i.data.assignee.login === a.login;
          }

--- a/ember-app/app/services/filter_groups/user.js
+++ b/ember-app/app/services/filter_groups/user.js
@@ -8,7 +8,7 @@ var UserFilters = Ember.Service.extend({
     this.set("filters", [
       Ember.Object.create({
         name: "Unassigned issues",
-        queryParam: "member",
+        queryParam: "assignee",
         mode: 0,
         condition: function(i){
           return !i.data.assignee;
@@ -20,7 +20,7 @@ var UserFilters = Ember.Service.extend({
       this.get("filters").insertAt(0, 
         Ember.Object.create({
           name: "Assigned to me",
-          queryParam: "member",
+          queryParam: "assignee",
           mode: 0,
           condition: function(i){
             return i.data.assignee && i.data.assignee.login === App.get("currentUser").login;
@@ -29,7 +29,7 @@ var UserFilters = Ember.Service.extend({
       this.get("filters").insertAt(1, 
         Ember.Object.create({
           name: "Assigned to others",
-          queryParam: "member",
+          queryParam: "assignee",
           mode: 0,
           condition: function(i){
             return i.data.assignee && i.data.assignee.login !== App.get("currentUser").login;

--- a/ember-app/app/services/query-params.js
+++ b/ember-app/app/services/query-params.js
@@ -34,6 +34,12 @@ var queryParamsService = Ember.Service.extend({
     });
     return filters;
   }.property("{repo,assignee,milestone,label,card}Params"),
+  anyParamsPresent: function(){
+    var allFilterParams = this.get('allFilterParams');
+    return this.get('filterNames').any((param)=>{
+      return allFilterParams[param].length;
+    });
+  }.property('allFilterParams.{repo,assignee,milestone,label,card}.length'),
 
   filtersReady: function(){
     if(this.get("filters.filtersReady")){
@@ -83,21 +89,14 @@ var queryParamsService = Ember.Service.extend({
   //Buffer the Filter Params for transitions (controllers initialization wipes them)
   filterParamsBuffer: {},
   updateFilterParamsBuffer: function(){
-    if(this.get("allFilterParams").length){
-      this.set("filterParamsBuffer", {
-        active: true,
-        repo: this.get("repoParams"),
-        assignee: this.get("assigneeParams"),
-        milestone: this.get("milestoneParams"),
-        label: this.get("labelParams"),
-        card: this.get("cardParams")
-      });
+    if(this.get('anyParamsPresent')){
+      this.set("filterParamsBuffer", this.get('allFilterParams'));
+      this.set("filterParamsBuffer.active", true);
     }
-  }.observes("allFilterParams.[]"),
+  }.observes("anyParamsPresent", "allFilterParams"),
   applyFilterBuffer: function(){
     var buffer = this.get("filterParamsBuffer");
-    var params = this.get("allFilterParams");
-    if(buffer.active && !params.length){
+    if(buffer.active && !this.get('anyParamsPresent')){
       this.set("repoParams", buffer.repo);
       this.set("assigneeParams", buffer.assignee);
       this.set("milestoneParams", buffer.milestone);

--- a/ember-app/app/services/query-params.js
+++ b/ember-app/app/services/query-params.js
@@ -27,10 +27,12 @@ var queryParamsService = Ember.Service.extend({
   filterNames: ["repo", "assignee", "milestone", "label", "card"],
   allFilterParams: function(){
     var self = this;
-    var filters = this.get("filterNames").map(function(param){
-      return self.get(`${param}Params`);
+    var filters = {length: 0};
+    this.get("filterNames").forEach(function(param){
+      filters.length = filters.length + 1;
+      filters[param] = self.get(`${param}Params`);
     });
-    return _.flatten(filters);
+    return filters;
   }.property("{repo,assignee,milestone,label,card}Params"),
 
   filtersReady: function(){
@@ -66,12 +68,15 @@ var queryParamsService = Ember.Service.extend({
   //Pushes URL filters down to the filter objects on load
   applyFilterParams: function(){
     var legacyMatch = this.legacyFilterMatch;
-    var all_filters = this.get("filters.allFilters");
-    this.get("allFilterParams").forEach(function(param){
-      var filters = all_filters.filter(function(filter){
-        return filter.name === param || legacyMatch(filter.name) === param;
-      });
-      filters.setEach("mode", 2);
+    var allFilterParams = this.get('allFilterParams');
+    this.get('filters.allFilters').forEach((filter)=>{
+      var paramsForFilter = allFilterParams[filter.queryParam];
+      if(paramsForFilter && paramsForFilter.length){
+        var filterIsPresent = paramsForFilter.any((p)=> {
+          return p === filter.name || p === legacyMatch(filter.name);
+        });
+        if(filterIsPresent){ filter.set('mode', 2); }
+      }
     });
   },
 


### PR DESCRIPTION
### Problem:

An example would be a label named 'pizza' and a repo named 'pizza' - a url with query parameters to filter on the label pizza would also trigger the repo 'pizza' filter. 

### Solution:

The Query Parameters now only apply themselves to the filter group they belong to.

fixes https://github.com/huboard/huboard-web/issues/310