### PR TITLE
Disables ajax caching in Ember

### DIFF
--- a/ember-app/app/app.js
+++ b/ember-app/app/app.js
@@ -3,6 +3,7 @@ import Resolver from 'ember/resolver';
 import loadInitializers from 'ember/load-initializers';
 import config from './config/environment';
 
+Ember.$.ajaxSetup({ cache: false });
 Ember.MODEL_FACTORY_INJECTIONS = true;
 
 Ember.LinkComponent.reopen({


### PR DESCRIPTION
Some browsers (specifically FF) use cached ajax responses when the browser restores tabs by default. This can cause chaos when cards start getting moved that are not actually there, and just a general poor experience. 

Relates to the conversation happening here: https://github.com/huboard/huboard/issues/677