### PR TITLE
Removes issue assignee key for new issues unless it has been set

### DIFF
--- a/lib/bridge/github/issues.rb
+++ b/lib/bridge/github/issues.rb
@@ -48,10 +48,10 @@ class Huboard
         title: issue.title,
         body: issue.body,
         labels: [labels.first['name']].concat((issue.labels || []).map{|l| l["name"]}),
-        assignee: assignee,
         assignees: issue['assignees'],
         milestone: milestone
       }
+      attributes[:assignee] = issue['assignee'] if issue['assignee']
 
       result = gh.issues.create(attributes) do |request|
         request.headers["Accept"] = "application/vnd.github.cerberus-preview.full+json"


### PR DESCRIPTION
It seems a silent push to the GitHub API disallows creating issues with both `assignee` & `assignees` keys for the cerebrus (multi-assignees) preview