### PR TITLE
Dissallows posting of null assignees

### DIFF
--- a/lib/bridge/github/issues.rb
+++ b/lib/bridge/github/issues.rb
@@ -48,7 +48,7 @@ class Huboard
         title: issue.title,
         body: issue.body,
         labels: [labels.first['name']].concat((issue.labels || []).map{|l| l["name"]}),
-        assignees: issue['assignees'],
+        assignees: issue['assignees'] || [],
         milestone: milestone
       }
       attributes[:assignee] = issue['assignee'] if issue['assignee']


### PR DESCRIPTION
It seems some browsers are passing down `null` for empty arrays. 