### PR TITLE
Disallow assignee key from being included in the payload of a multi-assignee new issue

### DIFF
--- a/ember-app/app/models/new/repo.js
+++ b/ember-app/app/models/new/repo.js
@@ -189,6 +189,7 @@ var Repo = Model.extend({
     var issue = form.serialize(["repo"]),
       repo = this;
     if(issue.assignees && issue.assignees.length){
+      issue.assignee = null;
       issue.assignees = issue.assignees.map((assignee)=>{  return assignee.login; });
     }
     return ajax({

--- a/lib/bridge/github/issues.rb
+++ b/lib/bridge/github/issues.rb
@@ -51,7 +51,7 @@ class Huboard
         assignees: issue['assignees'] || [],
         milestone: milestone
       }
-      attributes[:assignee] = issue['assignee'] if issue['assignee']
+      attributes[:assignee] = assignee if assignee
 
       result = gh.issues.create(attributes) do |request|
         request.headers["Accept"] = "application/vnd.github.cerberus-preview.full+json"


### PR DESCRIPTION
I noticed there are still a few situations where and assignee payload is slipping through (probably via older client code)