### PR TITLE
Treat blocked/ready labels as states

### DIFF
--- a/app/assets/stylesheets/_board.scss
+++ b/app/assets/stylesheets/_board.scss
@@ -28,6 +28,36 @@
       &:hover {
         color: #666;
       }
+      @-webkit-keyframes pulsate {
+        0%{opacity: 0.5;}
+        50%{opacity: 1.0;}
+        100%{opacity: 0.5;}
+      }
+      @-moz-keyframes pulsate {
+        0%{opacity: 0.5;}
+        50%{opacity: 1.0;}
+        100%{opacity: 0.5;}
+      }
+      @-ms-keyframes pulsate {
+        0%{opacity: 0.5;}
+        50%{opacity: 1.0;}
+        100%{opacity: 0.5;}
+      }
+      @-o-keyframes pulsate {
+        0%{opacity: 0.5;}
+        50%{opacity: 1.0;}
+        100%{opacity: 0.5;}
+      }
+      @keyframes pulsate {
+        0%{opacity: 0.5;}
+        50%{opacity: 1.0;}
+        100%{opacity: 0.5;}
+      }
+      .ui-icon-error {
+        @include animation(pulsate 2s ease-out);
+        @include animation-iteration-count(infinite);
+        opacity: 0.5;
+      }
     }
   }
    a {

--- a/ember-app/app/components/hb-selected-column.js
+++ b/ember-app/app/components/hb-selected-column.js
@@ -16,12 +16,15 @@ var HbSelectedColumnComponent = Ember.Component.extend({
     if(github_state === "closed"){
       return "hb-state-" + "closed";
     }
-    var custom_state = this.get("issue.customState");
+    var custom_state = this.get("issue.customState") ||
+      this.get('issue.other_labels').map((label)=> { return label.name }).find((name)=>{
+      return name === 'blocked' || name === 'ready'
+    });
     if(custom_state){
       return "hb-state-" + custom_state;
     }
     return "hb-state-open";
-  }.property("issue.data.current_state", "issue.customState", "issue.data.state"),
+  }.property("issue.data.current_state", "issue.customState", "issue.data.state", "issue.data.other_labels.[]"),
   selectedColumn: function () {
     if(this.get("issue.data.state") === "closed"){
       return this.get("columns.lastObject");

--- a/ember-app/app/components/hb-selected-column.js
+++ b/ember-app/app/components/hb-selected-column.js
@@ -16,10 +16,8 @@ var HbSelectedColumnComponent = Ember.Component.extend({
     if(github_state === "closed"){
       return "hb-state-" + "closed";
     }
-    var custom_state = this.get("issue.customState") ||
-      this.get('issue.other_labels').map((label)=> { return label.name }).find((name)=>{
-      return name === 'blocked' || name === 'ready'
-    });
+
+    var custom_state = this.get("issue.customState");
     if(custom_state){
       return "hb-state-" + custom_state;
     }

--- a/ember-app/app/components/hb-task-card.js
+++ b/ember-app/app/components/hb-task-card.js
@@ -108,15 +108,9 @@ var HbCardComponent = Ember.Component.extend(
          return "hb-state-" + custom_state;
        }
        return "hb-state-open";
-    }.property("issue.data.current_state", "issue.customState", "issue.data.state"),
-    isReady: function(){
-      return this.get('stateClass') === 'hb-state-ready' ||
-        this.get('issue.other_labels').isAny('name', 'ready');
-    }.property('stateClass', 'issue.data.other_labels.[]'),
-    isBlocked: function(){
-      return this.get('stateClass') === 'hb-state-blocked' ||
-        this.get('issue.other_labels').isAny('name', 'blocked');
-    }.property('stateClass', 'issue.data.other_labels.[]'),
+    }.property("issue.data.current_state", "issue.customState", "issue.data.state", "issue.data.other_labels.[]"),
+    isReady: Ember.computed.equal('stateClass', 'hb-state-ready'),
+    isBlocked: Ember.computed.equal('stateClass', 'hb-state-blocked'),
 
     registerToColumn: function(){
       this.set("cards", this.get("parentView.cards"));

--- a/ember-app/app/components/hb-task-card.js
+++ b/ember-app/app/components/hb-task-card.js
@@ -109,8 +109,14 @@ var HbCardComponent = Ember.Component.extend(
        }
        return "hb-state-open";
     }.property("issue.data.current_state", "issue.customState", "issue.data.state"),
-    isReady: Ember.computed.equal('stateClass', 'hb-state-ready'),
-    isBlocked: Ember.computed.equal('stateClass', 'hb-state-blocked'),
+    isReady: function(){
+      return this.get('stateClass') === 'hb-state-ready' ||
+        this.get('issue.other_labels').isAny('name', 'ready');
+    }.property('stateClass', 'issue.data.other_labels.[]'),
+    isBlocked: function(){
+      return this.get('stateClass') === 'hb-state-blocked' ||
+        this.get('issue.other_labels').isAny('name', 'blocked');
+    }.property('stateClass', 'issue.data.other_labels.[]'),
 
     registerToColumn: function(){
       this.set("cards", this.get("parentView.cards"));

--- a/ember-app/app/controllers/issue.js
+++ b/ember-app/app/controllers/issue.js
@@ -18,7 +18,7 @@ var IssueController = Ember.Controller.extend(
   isReady: Ember.computed("model.customState", "model.data._data.custom_state", "model.data.other_labels.[]", {
     get: function() {
       return this.get("model.customState") === "ready" ||
-        this.get("model.other_labels").isAny("name", "ready");
+        this.get("model.stateLabel") === "ready";
     },
     set: function(key, value){
       if(value) {
@@ -33,7 +33,7 @@ var IssueController = Ember.Controller.extend(
   isBlocked: Ember.computed("model.customState", "model.data._data.custom_state", "model.data.other_labels.[]", {
     get: function() {
       return this.get("model.customState") === "blocked" ||
-        this.get("model.other_labels").isAny("name", "blocked");
+        this.get("model.stateLabel") === "blocked";
     },
     set: function(key, value){
       if(value) {

--- a/ember-app/app/controllers/issue.js
+++ b/ember-app/app/controllers/issue.js
@@ -17,8 +17,7 @@ var IssueController = Ember.Controller.extend(
   columns: Ember.computed.alias("application.model.board.columns"),
   isReady: Ember.computed("model.customState", "model.data._data.custom_state", "model.data.other_labels.[]", {
     get: function() {
-      return this.get("model.customState") === "ready" ||
-        this.get("model.stateLabel") === "ready";
+      return this.get("model.customState") === "ready";
     },
     set: function(key, value){
       if(value) {
@@ -32,8 +31,7 @@ var IssueController = Ember.Controller.extend(
   }),
   isBlocked: Ember.computed("model.customState", "model.data._data.custom_state", "model.data.other_labels.[]", {
     get: function() {
-      return this.get("model.customState") === "blocked" ||
-        this.get("model.stateLabel") === "blocked";
+      return this.get("model.customState") === "blocked";
     },
     set: function(key, value){
       if(value) {

--- a/ember-app/app/controllers/issue.js
+++ b/ember-app/app/controllers/issue.js
@@ -15,9 +15,10 @@ var IssueController = Ember.Controller.extend(
     return this.get("model.repo.isCollaborator");
   }.property("model.repo.isCollaborator"),
   columns: Ember.computed.alias("application.model.board.columns"),
-  isReady: Ember.computed("model.customState", "model.data._data.custom_state", {
+  isReady: Ember.computed("model.customState", "model.data._data.custom_state", "model.data.other_labels.[]", {
     get: function() {
-      return this.get("model.customState") === "ready";
+      return this.get("model.customState") === "ready" ||
+        this.get("model.other_labels").isAny("name", "ready");
     },
     set: function(key, value){
       if(value) {
@@ -29,9 +30,10 @@ var IssueController = Ember.Controller.extend(
       }
     }
   }),
-  isBlocked: Ember.computed("model.customState", "model.data._data.custom_state", {
+  isBlocked: Ember.computed("model.customState", "model.data._data.custom_state", "model.data.other_labels.[]", {
     get: function() {
-      return this.get("model.customState") === "blocked";
+      return this.get("model.customState") === "blocked" ||
+        this.get("model.other_labels").isAny("name", "blocked");
     },
     set: function(key, value){
       if(value) {

--- a/ember-app/app/mixins/subscriptions/card.js
+++ b/ember-app/app/mixins/subscriptions/card.js
@@ -43,7 +43,7 @@ var CardSubscriptionMixin = Ember.Mixin.create({
         }
       }
       this.set("issue.assignee", message.issue.assignee);
-    }, {time: 5000, sort: function(a,b){
+    }, {time: 2000, sort: function(a,b){
       var timeA = Date.parse(a.issue.updated_at);
       var timeB = Date.parse(b.issue.updated_at);
       return timeA - timeB;
@@ -57,7 +57,7 @@ var CardSubscriptionMixin = Ember.Mixin.create({
           this.get("issue.assignees").removeObject(assignee);
         }
       }
-    }, {time: 5000, sort: function(a,b){
+    }, {time: 2000, sort: function(a,b){
       var timeA = Date.parse(a.issue.updated_at);
       var timeB = Date.parse(b.issue.updated_at);
       return timeA - timeB;
@@ -87,7 +87,7 @@ var CardSubscriptionMixin = Ember.Mixin.create({
         });
         if(!match){ return this.get("issue.data.other_labels").addObject(message.label); }
       }
-    }, {time: 5000, sort: function(a,b){
+    }, {time: 2000, sort: function(a,b){
       var timeA = Date.parse(a.issue.updated_at);
       var timeB = Date.parse(b.issue.updated_at);
       return timeA - timeB;
@@ -101,7 +101,7 @@ var CardSubscriptionMixin = Ember.Mixin.create({
           this.get("issue.data.other_labels").removeObject(match);
         }
       }
-    }, {time: 5000, sort: function(a,b){
+    }, {time: 2000, sort: function(a,b){
       var timeA = Date.parse(a.issue.updated_at);
       var timeB = Date.parse(b.issue.updated_at);
       return timeA - timeB;

--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -154,12 +154,12 @@ var Issue = Model.extend({
   }.observes('stateLabel'),
   customState: Ember.computed("data._data.custom_state", "data.other_labels.[]", {
     get:function(){
-      var state = this.get("_data.custom_state");
+      var state = this.get("stateLabel");
       if(state){ return state; }
-      return this.get('stateLabel');
+      return this.get("_data.custom_state");
     },
     set: function (key, value) {
-      var previousState = this.get("_data.custom_state") || this.get("stateLabel");
+      var previousState = this.get("stateLabel") || this.get("_data.custom_state");
       this.set("_data.custom_state", value);
 
       var endpoint = value === "" ? previousState : value;

--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -184,6 +184,7 @@ var Issue = Model.extend({
       this.set("_data.custom_state", value);
 
       var endpoint = value === "" ? previousState : value;
+      if(!endpoint){ return; }
       var options = {
         dataType: "json",
         data: {correlationId: this.get("correlationId")},

--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -167,17 +167,14 @@ var Issue = Model.extend({
         return name === 'blocked' || name === 'ready';
     }) || '';
   }.property('data.other_labels.[]'),
-  stateLabelObserver: function(){
-    if(this.get('stateLabel')){this.set('_data.custom_state', this.get('stateLabel'));}
-  }.observes('stateLabel'),
-  customState: Ember.computed("data._data.custom_state", "data.other_labels.[]", {
+  customState: Ember.computed("data._data.custom_state", "data.other_labels.[]", "stateLabel", {
     get:function(){
       var state = this.get("stateLabel");
       if(state){ return state; }
       return this.get("_data.custom_state");
     },
     set: function (key, value) {
-      var previousState = this.get("stateLabel") || this.get("_data.custom_state");
+      var previousState = this.get("_data.custom_state") || this.get("stateLabel");
       this.set("_data.custom_state", value);
 
       var endpoint = value === "" ? previousState : value;
@@ -192,9 +189,9 @@ var Issue = Model.extend({
       Ember.$.ajax(options)
       .then(function(response){
         this.set("processing", false);
-        this.set("other_labels", response.other_labels);
         this.set("data.body", response.body);
         this.set("data.body_html", response.body_html);
+        this.set("other_labels", response.other_labels);
       }.bind(this));
 
       return value;

--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -168,7 +168,7 @@ var Issue = Model.extend({
     }) || '';
   }.property('data.other_labels.[]'),
   stateLabelObserver: function(){
-    this.set('_data.custom_state', this.get('stateLabel'));
+    if(this.get('stateLabel')){this.set('_data.custom_state', this.get('stateLabel'));}
   }.observes('stateLabel'),
   customState: Ember.computed("data._data.custom_state", "data.other_labels.[]", {
     get:function(){

--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -161,6 +161,7 @@ var Issue = Model.extend({
       Ember.$.ajax(options)
       .then(function(response){
         this.set("processing", false);
+        this.set("other_labels", response.other_labels);
         this.set("data.body", response.body);
         this.set("data.body_html", response.body_html);
       }.bind(this));

--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -74,7 +74,7 @@ var Issue = Model.extend({
   },
   reorder: function (index, column) {
     var changedColumns = this.get("data.current_state.index") !== column.data.index;
-    if(changedColumns){ this.set("data._data.custom_state", ""); }
+    if(changedColumns){ this.handleColumnChange(); }
 
     this.set("data.current_state", column.data);
     this.set("data._data.order", index);
@@ -88,6 +88,16 @@ var Issue = Model.extend({
       this.set("data.body_html", response.body_html);
       return this;
     }.bind(this), "json");
+  },
+  handleColumnChange: function(){
+    this.set("data._data.custom_state", ""); 
+    var state_label = this.get('other_labels').find((label)=> { 
+      return label.name.toLowerCase() === this.get('stateLabel');
+    });
+    if(state_label){ 
+      this.get('other_labels').removeObject(state_label);
+      this.updateLabels(state_label, 'unlabel'); 
+    }
   },
   close: function () {
     this.set("processing", true);

--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -180,7 +180,7 @@ var Issue = Model.extend({
       return this.get("_data.custom_state");
     },
     set: function (key, value) {
-      var previousState =  this.get("stateLabel") || this.get("_data.custom_state");
+      var previousState = this.get("stateLabel") || this.get("_data.custom_state");
       this.set("_data.custom_state", value);
 
       var endpoint = value === "" ? previousState : value;

--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -60,17 +60,23 @@ var Issue = Model.extend({
       contentType: "application/json"})
       .then(function(){
         this.set("processing", false);
+        if(this.isStateLabel(label) && action === 'unlabel'){
+          this.set('customState', '');
+        }
       }.bind(this));
   },
   checkForStateChange: function(label){
-    var name = label.name.toLowerCase();
-    if(name === 'blocked' || name === 'ready'){
-      var conflict_state = name === 'blocked' ? 'ready' : 'blocked';
+    if(this.isStateLabel(label)){
+      var conflict_state = label.name.toLowerCase() === 'blocked' ? 'ready' : 'blocked';
       var conflict_label = this.get('other_labels').find((label)=>{
         return label.name.toLowerCase() === conflict_state;
       });
       this.get('other_labels').removeObject(conflict_label);
     }
+  },
+  isStateLabel: function(label){
+    var name = label.name.toLowerCase();
+    return name === 'blocked' || name === 'ready';
   },
   reorder: function (index, column) {
     var changedColumns = this.get("data.current_state.index") !== column.data.index;
@@ -163,8 +169,8 @@ var Issue = Model.extend({
     }, function(){}, "json");
   },
   stateLabel: function(){
-    return this.get('other_labels').map((label)=>{ return label.name.toLowerCase(); }).find((name)=>{
-        return name === 'blocked' || name === 'ready';
+    return this.get('other_labels').find((label)=>{
+        return this.isStateLabel(label);
     }) || '';
   }.property('data.other_labels.[]'),
   customState: Ember.computed("data._data.custom_state", "data.other_labels.[]", "stateLabel", {

--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -80,7 +80,7 @@ var Issue = Model.extend({
   },
   reorder: function (index, column) {
     var changedColumns = this.get("data.current_state.index") !== column.data.index;
-    if(changedColumns){ this.handleColumnChange(); }
+    if(changedColumns){ this.set("data._data.custom_state", ""); }
 
     this.set("data.current_state", column.data);
     this.set("data._data.order", index);
@@ -92,11 +92,11 @@ var Issue = Model.extend({
     }, function( response ){
       this.set("data.body", response.body);
       this.set("data.body_html", response.body_html);
+      if(changedColumns){ return this.handleColumnChange(); }
       return this;
     }.bind(this), "json");
   },
   handleColumnChange: function(){
-    this.set("data._data.custom_state", ""); 
     var state_label = this.get('other_labels').find((label)=> { 
       return label.name.toLowerCase() === this.get('stateLabel');
     });

--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -141,12 +141,25 @@ var Issue = Model.extend({
       correlationId: this.get("correlationId")
     }, function(){}, "json");
   },
-  customState: Ember.computed("data._data.custom_state", {
+  stateLabel: function(){
+    var state_label = this.get('other_labels').map((label)=> {
+        return label.name.toLowerCase();
+      }).find((name)=>{
+        return name.toLowerCase() === 'blocked' || name.toLowerCase() === 'ready';
+    });
+    return state_label || "";
+  }.property('data.other_labels.[]'),
+  stateLabelObserver: function(){
+    this.set('_data.custom_state', this.get('stateLabel'));
+  }.observes('stateLabel'),
+  customState: Ember.computed("data._data.custom_state", "data.other_labels.[]", {
     get:function(){
-      return this.get("_data.custom_state");
+      var state = this.get("_data.custom_state");
+      if(state){ return state; }
+      return this.get('stateLabel');
     },
     set: function (key, value) {
-      var previousState = this.get("_data.custom_state");
+      var previousState = this.get("_data.custom_state") || this.get("stateLabel");
       this.set("_data.custom_state", value);
 
       var endpoint = value === "" ? previousState : value;

--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -169,8 +169,8 @@ var Issue = Model.extend({
     }, function(){}, "json");
   },
   stateLabel: function(){
-    return this.get('other_labels').find((label)=>{
-        return this.isStateLabel(label);
+    return this.get('other_labels').map((label)=>{return label.name.toLowerCase()}).find((name)=>{
+      return name === 'blocked' || name === 'ready';
     }) || '';
   }.property('data.other_labels.[]'),
   customState: Ember.computed("data._data.custom_state", "data.other_labels.[]", "stateLabel", {
@@ -180,7 +180,7 @@ var Issue = Model.extend({
       return this.get("_data.custom_state");
     },
     set: function (key, value) {
-      var previousState = this.get("_data.custom_state") || this.get("stateLabel");
+      var previousState =  this.get("stateLabel") || this.get("_data.custom_state");
       this.set("_data.custom_state", value);
 
       var endpoint = value === "" ? previousState : value;

--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -166,7 +166,7 @@ var Issue = Model.extend({
     return this.get('other_labels').map((label)=>{ return label.name.toLowerCase(); }).find((name)=>{
         return name === 'blocked' || name === 'ready';
     }) || '';
-  }.property('data.other_labels.[]', 'lastLabelUpdated.name'),
+  }.property('data.other_labels.[]'),
   stateLabelObserver: function(){
     this.set('_data.custom_state', this.get('stateLabel'));
   }.observes('stateLabel'),

--- a/lib/bridge/github/issues.rb
+++ b/lib/bridge/github/issues.rb
@@ -232,13 +232,10 @@ class Huboard
       end
 
       def label_as_marked(label)
-        color = label == 'blocked' ? 'f9646e' : '22d186'
-        new_label = {'name' => label, 'color' => color }
         board = Huboard::Board.new(self[:repo][:owner][:login], self[:repo][:name], @connection_factory)
-        if !board.other_labels.any?{|l| l['name'].downcase == label}
-          board.create_label(new_label)
+        if board.other_labels.any?{|l| l['name'].downcase == label}
+          self['labels'].push({'name' => label})
         end
-        self['labels'].push(new_label)
       end
 
       def archive(labels)

--- a/lib/health_checking/board_exam.rb
+++ b/lib/health_checking/board_exam.rb
@@ -27,6 +27,8 @@ module HealthChecking
       HealthChecks::Board::IssuesWebhookCheck,
       HealthChecks::Board::IssueCommentWebhookCheck,
       HealthChecks::Board::PullRequestWebhookCheck,
+      HealthChecks::Board::IssueBlockedLabelCheck,
+      HealthChecks::Board::IssueReadyLabelCheck
     ]
 
   end

--- a/lib/health_checking/health_checks/board/issue_blocked_label_check.rb
+++ b/lib/health_checking/health_checks/board/issue_blocked_label_check.rb
@@ -1,0 +1,31 @@
+module HealthChecking
+  module HealthChecks
+    module Board
+      class IssueBlockedLabelCheck
+        include HealthCheck
+        name 'issue_blocked_label_check'
+        weight :warning
+        authorization :collaborator
+        passed "Issue blocked label is present"
+        failed "Issue blocked label is not present"
+
+        ## deps
+        # {
+        #   board: board object,
+        #   authorization: :all, :collaborator or :admin
+        #   logged_in: bool
+        # }
+        ##
+
+        def perform(deps)
+          return deps[:board].other_labels.any?{|label| label['name'].downcase === 'blocked'}
+        end
+         
+        def treat(deps)
+          return deps[:board].create_label({name: 'blocked', color: 'f9646e'})
+        end
+      end
+    end
+  end
+end
+

--- a/lib/health_checking/health_checks/board/issue_blocked_label_check.rb
+++ b/lib/health_checking/health_checks/board/issue_blocked_label_check.rb
@@ -6,8 +6,8 @@ module HealthChecking
         name 'issue_blocked_label_check'
         weight :warning
         authorization :collaborator
-        passed "Issue blocked label is present"
-        failed "Issue blocked label is not present"
+        passed "'Blocked' label is present"
+        failed "'Blocked' label is not present"
 
         ## deps
         # {

--- a/lib/health_checking/health_checks/board/issue_ready_label_check.rb
+++ b/lib/health_checking/health_checks/board/issue_ready_label_check.rb
@@ -6,8 +6,8 @@ module HealthChecking
         name 'issue_ready_label_check'
         weight :warning
         authorization :collaborator
-        passed "Issue ready label is present"
-        failed "Issue ready label is not present"
+        passed "'Ready' label is present"
+        failed "'Ready' label is not present"
 
         ## deps
         # {

--- a/lib/health_checking/health_checks/board/issue_ready_label_check.rb
+++ b/lib/health_checking/health_checks/board/issue_ready_label_check.rb
@@ -1,0 +1,31 @@
+module HealthChecking
+  module HealthChecks
+    module Board
+      class IssueReadyLabelCheck
+        include HealthCheck
+        name 'issue_ready_label_check'
+        weight :warning
+        authorization :collaborator
+        passed "Issue ready label is present"
+        failed "Issue ready label is not present"
+
+        ## deps
+        # {
+        #   board: board object,
+        #   authorization: :all, :collaborator or :admin
+        #   logged_in: bool
+        # }
+        ##
+
+        def perform(deps)
+          return deps[:board].other_labels.any?{|label| label['name'].downcase === 'ready'}
+        end
+         
+        def treat(deps)
+          return deps[:board].create_label({name: 'ready', color: '22d186'})
+        end
+      end
+    end
+  end
+end
+

--- a/test/specs/lib/health_checking/health_checks/board/issue_blocked_label_check_test.rb
+++ b/test/specs/lib/health_checking/health_checks/board/issue_blocked_label_check_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+describe 'IssueBlockedLabelCheck' do
+
+  it 'performs' do
+    mock_board = mock('Board Object')
+    mock_board.stubs(:other_labels).returns([{'name' => 'blocked'}])
+
+    deps = {board: mock_board}
+    sut = HealthChecking::HealthChecks::Board::IssueBlockedLabelCheck.new
+
+    result = sut.perform(deps)
+    assert_equal(true, result)
+  end
+
+  it 'treats' do
+    mock_board = mock('Board Object')
+    mock_board.stubs(:create_label).returns(true)
+
+    deps = {board: mock_board}
+    sut = HealthChecking::HealthChecks::Board::IssueBlockedLabelCheck.new
+
+    result = sut.treat(deps)
+    assert_equal(true, result)
+  end
+end

--- a/test/specs/lib/health_checking/health_checks/board/issue_ready_label_check_test.rb
+++ b/test/specs/lib/health_checking/health_checks/board/issue_ready_label_check_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+describe 'IssueReadyLabelCheck' do
+
+  it 'performs' do
+    mock_board = mock('Board Object')
+    mock_board.stubs(:other_labels).returns([{'name' => 'ready'}])
+
+    deps = {board: mock_board}
+    sut = HealthChecking::HealthChecks::Board::IssueReadyLabelCheck.new
+
+    result = sut.perform(deps)
+    assert_equal(true, result)
+  end
+
+  it 'treats' do
+    mock_board = mock('Board Object')
+    mock_board.stubs(:create_label).returns(true)
+
+    deps = {board: mock_board}
+    sut = HealthChecking::HealthChecks::Board::IssueReadyLabelCheck.new
+
+    result = sut.treat(deps)
+    assert_equal(true, result)
+  end
+end


### PR DESCRIPTION
Merges https://github.com/huboard/huboard-web/pull/327  (the card design branch.)

Blocked/Ready labels now act readily as states on HuBoard. If the label is missing <s>it is created</s> the health check fails. 

closes https://github.com/huboard/huboard/issues/399