### PR TITLE
Fixes events for multi-assignees duplicating the assignee

### DIFF
--- a/ember-app/app/mixins/subscriptions/card.js
+++ b/ember-app/app/mixins/subscriptions/card.js
@@ -36,10 +36,10 @@ var CardSubscriptionMixin = Ember.Mixin.create({
       var assignees = this.get("issue.assignees");
       if(assignees && !assignees.isAny("login", message.assignee.login)){
         if(message.assignee.login){
-          this.get("issue.assignees").pushObject(message.assignee);
+          return this.get("issue.assignees").pushObject(message.assignee);
         } else {
           var assignee = this.get("issue.repo.assignees").findBy("login", message.assignee);
-          this.get("issue.assignees").pushObject(assignee);
+          return this.get("issue.assignees").pushObject(assignee);
         }
       }
       this.set("issue.assignee", message.issue.assignee);


### PR DESCRIPTION
Now that multiple assignees are supported on cards, I observed cases where both the primary assignee and the assignee in the `assignees` payload both being pushed onto the card. 