### PR TITLE
Milestone Card Layout

### DIFF
--- a/app/assets/stylesheets/_board.scss
+++ b/app/assets/stylesheets/_board.scss
@@ -564,29 +564,8 @@
       white-space: normal;
       overflow: auto;
     }
-    .hb-avatar-tooltip {
-      &:hover {
-        p {
-          display: inline-table;
-          visibility: visible;
-        }
-      }
-      p {
-        bottom: 42px;
-        top: 5px;
-        left: 34px;
-        line-height: 16px;
-        &:after {
-          content: "\25C0";
-          color: $hb-purple;
-          left: -6px;
-          bottom: 1px;
-        }
-      }
-      display: inline;
-      img {
-        position: static;
-      }
+    .card-details-wrapper {
+      float: right;
     }
     .card-header {
       border-bottom: none;

--- a/app/assets/stylesheets/_board.scss
+++ b/app/assets/stylesheets/_board.scss
@@ -567,6 +567,20 @@
     .card-details-wrapper {
       float: right;
     }
+    .avatar-wrapper {
+      .assignee-overflow {
+        color: $lightGrey;
+        font-size: 12px;
+        position: relative;
+        margin-left: -24px;
+        top: 2px;
+      }
+      &:hover {
+        .assignee-overflow {
+          display: none;
+        }
+      }
+    }
     .card-header {
       border-bottom: none;
       padding: 5px 0px;

--- a/app/assets/stylesheets/_board.scss
+++ b/app/assets/stylesheets/_board.scss
@@ -548,6 +548,7 @@
   }
 
   &.card--milestone {
+    padding: 4px 2px 6px 4px;
     &.border {
       padding-left: 6px;
     }
@@ -569,16 +570,23 @@
     }
     .avatar-wrapper {
       .assignee-overflow {
-        color: $lightGrey;
-        font-size: 12px;
+        color: white;
+        background-color: $hb-purple-dark;
+        margin-left: -8px;
+        font-size: 11px;
         position: relative;
-        margin-left: -24px;
-        top: 2px;
+        float: right;
+        border-style: solid;
+        border-width: 1px;
+        border-radius: 8px;
+        bottom: 4px;
+        padding: 1px;
+        z-index: 101;
+        line-height: 12px;
+        text-align: center;
       }
-      &:hover {
-        .assignee-overflow {
-          display: none;
-        }
+      .visible-assignees {
+        float: left;
       }
     }
     .card-header {

--- a/app/assets/stylesheets/components/_column-indicator.scss
+++ b/app/assets/stylesheets/components/_column-indicator.scss
@@ -1,11 +1,11 @@
 .hb-column-indicator {
-  @include display(inline-block);
+  @include display(inline-flex);
   line-height: 16px;
   padding: 1px 6px;
   border: 1px solid $borderColor;
   border-radius: 2px;
   position: relative;
-  max-width: 84px;
+  max-width: 80px;
 
 
   &__text {
@@ -36,9 +36,9 @@
 
   .card-states {
     position:static;
-    float: right;
     height: 16px;
     width: 16px;
+    min-width: 16px;
     border-radius: 50%;
     margin: 1px 0px 1px 5px;
 

--- a/app/assets/stylesheets/components/_column-indicator.scss
+++ b/app/assets/stylesheets/components/_column-indicator.scss
@@ -5,7 +5,7 @@
   border: 1px solid $borderColor;
   border-radius: 2px;
   position: relative;
-  max-width: 80px;
+  max-width: 84px;
 
 
   &__text {
@@ -13,7 +13,7 @@
     left: 3px;
     position: relative;
     display: block;
-    font-size: 12px;
+    font-size: 11px;
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;

--- a/app/assets/stylesheets/components/_column-indicator.scss
+++ b/app/assets/stylesheets/components/_column-indicator.scss
@@ -4,6 +4,8 @@
   padding: 1px 6px;
   border: 1px solid $borderColor;
   border-radius: 2px;
+  position: relative;
+  top: 2px;
 
 
   &__text {

--- a/app/assets/stylesheets/components/_column-indicator.scss
+++ b/app/assets/stylesheets/components/_column-indicator.scss
@@ -5,13 +5,18 @@
   border: 1px solid $borderColor;
   border-radius: 2px;
   position: relative;
-  top: 2px;
+  max-width: 80px;
 
 
   &__text {
     color: $lightGrey;
-    margin-left: 3px;
+    left: 3px;
+    position: relative;
+    display: block;
     font-size: 12px;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
   }
 
   &__bar {

--- a/ember-app/app/components/hb-milestone-card.js
+++ b/ember-app/app/components/hb-milestone-card.js
@@ -6,7 +6,7 @@ var { get } = Ember;
 var HbMilestoneCard = HbCard.extend({
   classNames: ["card", "card--milestone"],
   taskCard: false,
-  powerBarLength: 4,
+  maxPowerBarLength: 4,
   columnIndicator: function(){
     let currentState = get(this, 'issue.current_state');
     var columns = this.get('taskColumns').map((c) => {
@@ -23,14 +23,15 @@ var HbMilestoneCard = HbCard.extend({
 
     var selected = columns.findBy('selected');
     var powerbar_total = columns.indexOf(selected);
-    var visible_columns = columns.slice(0, this.powerBarLength);
+    var powerBarLength = columns.length <= this.maxPowerBarLength ? columns.length - 1 : this.maxPowerBarLength;
+    var visible_columns = columns.slice(0, powerBarLength);
 
     // Calculate the powerbar progress proportionally
-    visible_columns = this.proportionalProgress(visible_columns, powerbar_total, columns.length);
+    visible_columns = this.proportionalProgress(visible_columns, powerbar_total, columns.length, powerBarLength);
 
     return visible_columns;
   }.property('issue.data.current_state', 'taskColumns'),
-  proportionalProgress: function(columns, powerbar_total, total_length){
+  proportionalProgress: function(columns, powerbar_total, total_length, powerBarLength){
     // If powerbar is on first column, as meters are empty
     if(!powerbar_total){ columns.setEach('selected', false); return columns; }
 
@@ -42,7 +43,7 @@ var HbMilestoneCard = HbCard.extend({
 
     // Otherwise calculate the proportional progress of the meter
     var percent_complete = powerbar_total / total_length;
-    var selected_columns_index = Math.ceil(percent_complete * this.powerBarLength) - 1;
+    var selected_columns_index = Math.ceil(percent_complete * powerBarLength) - 1;
 
     return columns.map((column, index)=>{
       if(index <= selected_columns_index && index !== (columns.length - 1)){

--- a/ember-app/app/components/hb-milestone-card.js
+++ b/ember-app/app/components/hb-milestone-card.js
@@ -46,7 +46,7 @@ var HbMilestoneCard = HbCard.extend({
 
     // Otherwise calculate the proportional progress of the meter
     var percentComplete = selectedIndex / (totalColumnCount - 1);
-    var proportionalColumnIndex = Math.ceil(percentComplete * (powerBarLength - 1));
+    var proportionalColumnIndex = Math.ceil(percentComplete * (powerBarLength - 1)) - 1;
 
     return columns.map((column, index)=>{
       return column.set('selected', index <= proportionalColumnIndex);

--- a/ember-app/app/components/hb-milestone-card.js
+++ b/ember-app/app/components/hb-milestone-card.js
@@ -31,7 +31,7 @@ var HbMilestoneCard = HbCard.extend({
 
     return visible_columns;
   }.property('issue.data.current_state', 'taskColumns'),
-  proportionalProgress: function(columns, selectedIndex, total_length, powerBarLength){
+  proportionalProgress: function(columns, selectedIndex, totalColumnCount, powerBarLength){
     // In first column, no bars are selected
     if(!selectedIndex){
       columns.setEach('selected', false);
@@ -39,13 +39,13 @@ var HbMilestoneCard = HbCard.extend({
     }
 
     // In last column, all bars are selected
-    if(selectedIndex === (total_length - 1)){
+    if(selectedIndex === (totalColumnCount - 1)){
       columns.setEach('selected', true);
       return columns;
     }
 
     // Otherwise calculate the proportional progress of the meter
-    var percent_complete = selectedIndex / total_length;
+    var percent_complete = selectedIndex / totalColumnCount;
     var selected_columns_index = Math.ceil(percent_complete * powerBarLength) - 1;
 
     return columns.map((column, index)=>{

--- a/ember-app/app/components/hb-milestone-card.js
+++ b/ember-app/app/components/hb-milestone-card.js
@@ -41,8 +41,8 @@ var HbMilestoneCard = HbCard.extend({
     }
 
     // Otherwise calculate the proportional progress of the meter
-    var percent_complete = (powerbar_total - 1) / total_length;
-    var selected_columns_index = Math.ceil(percent_complete * this.powerBarLength);
+    var percent_complete = powerbar_total / total_length;
+    var selected_columns_index = Math.ceil(percent_complete * this.powerBarLength) - 1;
 
     return columns.map((column, index)=>{
       if(index <= selected_columns_index && index !== (columns.length - 1)){

--- a/ember-app/app/components/hb-milestone-card.js
+++ b/ember-app/app/components/hb-milestone-card.js
@@ -34,6 +34,7 @@ var HbMilestoneCard = HbCard.extend({
       });
     });
 
+    columns = this.compressColumns(columns);
     takeWhile(columns, (x) => {return !get(x, 'selected');}, this)
       .forEach((x) => { set(x, 'selected', true); });
 
@@ -43,7 +44,17 @@ var HbMilestoneCard = HbCard.extend({
     var assignees = this.get('visibleAssignees') || [];
     this.set('assigneeOverflow', assignees.slice(3).length);
     return assignees.slice(0,3);
-  }.property('visibleAssignees.[]')
+  }.property('visibleAssignees.[]'),
+  compressColumns: function(columns){
+    while(columns.length > 5){
+      if(columns[0].get('selected') === false){
+        columns.shift();
+      } else {
+        columns.pop();
+      }
+    }
+    return columns;
+  }
 });
 
 export default HbMilestoneCard;

--- a/ember-app/app/components/hb-milestone-card.js
+++ b/ember-app/app/components/hb-milestone-card.js
@@ -45,15 +45,11 @@ var HbMilestoneCard = HbCard.extend({
     }
 
     // Otherwise calculate the proportional progress of the meter
-    var percent_complete = selectedIndex / totalColumnCount;
-    var selected_columns_index = Math.ceil(percent_complete * powerBarLength) - 1;
+    var percentComplete = selectedIndex / (totalColumnCount - 1);
+    var proportionalColumnIndex = Math.ceil(percentComplete * (powerBarLength - 1));
 
     return columns.map((column, index)=>{
-      if(index <= selected_columns_index && index !== (columns.length - 1)){
-        return column.set('selected', true);
-      } else {
-        return column.set('selected', false);
-      }
+      return column.set('selected', index <= proportionalColumnIndex);
     });
   },
   limitedAssignees: function(){

--- a/ember-app/app/components/hb-milestone-card.js
+++ b/ember-app/app/components/hb-milestone-card.js
@@ -38,7 +38,12 @@ var HbMilestoneCard = HbCard.extend({
       .forEach((x) => { set(x, 'selected', true); });
 
     return columns;
-  }.property('issue.data.current_state', 'taskColumns')
+  }.property('issue.data.current_state', 'taskColumns'),
+  limitedAssignees: function(){
+    var assignees = this.get('visibleAssignees') || [];
+    this.set('assigneeOverflow', assignees.slice(2).length);
+    return assignees.slice(0,3);
+  }.property('visibleAssignees.[]')
 });
 
 export default HbMilestoneCard;

--- a/ember-app/app/components/hb-milestone-card.js
+++ b/ember-app/app/components/hb-milestone-card.js
@@ -6,7 +6,7 @@ var { get } = Ember;
 var HbMilestoneCard = HbCard.extend({
   classNames: ["card", "card--milestone"],
   taskCard: false,
-  powerBarLength: 5,
+  powerBarLength: 4,
   columnIndicator: function(){
     let currentState = get(this, 'issue.current_state');
     var columns = this.get('taskColumns').map((c) => {

--- a/ember-app/app/components/hb-milestone-card.js
+++ b/ember-app/app/components/hb-milestone-card.js
@@ -41,7 +41,7 @@ var HbMilestoneCard = HbCard.extend({
   }.property('issue.data.current_state', 'taskColumns'),
   limitedAssignees: function(){
     var assignees = this.get('visibleAssignees') || [];
-    this.set('assigneeOverflow', assignees.slice(2).length);
+    this.set('assigneeOverflow', assignees.slice(3).length);
     return assignees.slice(0,3);
   }.property('visibleAssignees.[]')
 });

--- a/ember-app/app/components/hb-milestone-card.js
+++ b/ember-app/app/components/hb-milestone-card.js
@@ -22,27 +22,30 @@ var HbMilestoneCard = HbCard.extend({
     });
 
     var selected = columns.findBy('selected');
-    var powerbar_total = columns.indexOf(selected);
+    var selectedIndex = columns.indexOf(selected);
     var powerBarLength = columns.length <= this.maxPowerBarLength ? columns.length - 1 : this.maxPowerBarLength;
     var visible_columns = columns.slice(0, powerBarLength);
 
     // Calculate the powerbar progress proportionally
-    visible_columns = this.proportionalProgress(visible_columns, powerbar_total, columns.length, powerBarLength);
+    visible_columns = this.proportionalProgress(visible_columns, selectedIndex, columns.length, powerBarLength);
 
     return visible_columns;
   }.property('issue.data.current_state', 'taskColumns'),
-  proportionalProgress: function(columns, powerbar_total, total_length, powerBarLength){
-    // If powerbar is on first column, as meters are empty
-    if(!powerbar_total){ columns.setEach('selected', false); return columns; }
+  proportionalProgress: function(columns, selectedIndex, total_length, powerBarLength){
+    // In first column, no bars are selected
+    if(!selectedIndex){
+      columns.setEach('selected', false);
+      return columns;
+    }
 
-    // If powerbar is on last column, all meters are full
-    if(powerbar_total === (total_length - 1)){
+    // In last column, all bars are selected
+    if(selectedIndex === (total_length - 1)){
       columns.setEach('selected', true);
       return columns;
     }
 
     // Otherwise calculate the proportional progress of the meter
-    var percent_complete = powerbar_total / total_length;
+    var percent_complete = selectedIndex / total_length;
     var selected_columns_index = Math.ceil(percent_complete * powerBarLength) - 1;
 
     return columns.map((column, index)=>{

--- a/ember-app/app/models/new/column.js
+++ b/ember-app/app/models/new/column.js
@@ -23,10 +23,7 @@ var Column = Ember.Object.extend(Ember.PromiseProxyMixin, {
   filterStrategy: function(issue){
     var issue_index = issue.get("columnIndex");
     var same_column = issue_index === this.get("data.index");
-    if(this.get("isLastColumn")){
-      return same_column || (issue.data.state === "closed" && !issue.get("isArchived"));
-    }
-    return same_column && issue.data.state !== "closed";
+    return same_column;
   },
   sortStrategy: function(a,b){
     if(a.data._data.order === b.data._data.order){

--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -214,7 +214,13 @@ var Issue = Model.extend({
     while(order < 1e-319){ order *= 10; }
     while(order > 1e307){ order /= 10; }
     return order;
-  }
+  },
+  columnObserver: function(){
+    if(this.get('state') === 'closed'){
+      var last_column = this.get('repo.board.columns.lastObject.data');
+      this.set('current_state', last_column);
+    }
+  }.observes('repo.board.columns', 'state')
 });
 
 export default Issue;

--- a/ember-app/app/templates/components/hb-milestone-card.hbs
+++ b/ember-app/app/templates/components/hb-milestone-card.hbs
@@ -28,15 +28,15 @@
       </div>
     </div>
     <div class="hb-column-indicator">
+      {{#each columnIndicator as |column| }}
+        <div class='hb-column-indicator__bar {{if column.selected "selected"}}'></div>
+      {{/each}}
+      <span class="hb-column-indicator__text">{{issue.current_state.text}}</span>
       <div class="card-states">
         <img src="{{asset-path "check.png"}}" title="Issue is closed" class="hb-state-closed"/>
         <img src="{{asset-path 'arrow.png'}}" class="hb-state-ready"/>
         <img src="{{asset-path 'x.png'}}" class="hb-state-blocked"/>
       </div>
-      {{#each columnIndicator as |column| }}
-        <div class='hb-column-indicator__bar {{if column.selected "selected"}}'></div>
-      {{/each}}
-      <span class="hb-column-indicator__text">{{issue.current_state.text}}</span>
     </div>
 
 

--- a/ember-app/app/templates/components/hb-milestone-card.hbs
+++ b/ember-app/app/templates/components/hb-milestone-card.hbs
@@ -1,15 +1,29 @@
 <div class="ember-view">
   <div class="card-header">
     <div class="title" title="{{issue.title}}">
-      {{#if issue.assignee}}
-        {{hb-avatar-tooltip user=issue.assignee width="24" height="24"}}
-      {{/if}}
       {{issue.title}} 
       <small>#{{issue.number}}</small>
     </div>
   </div>
 
-  <div class="card-footer">
+  <div class="card-footer clearfix">
+    <div class="card-details-wrapper">
+      <div class="card-details clearfix">
+        <div class="avatar-wrapper">
+          {{#if issue.assignees}}
+            <div class="visible-assignees">
+              {{#each visibleAssignees as |assignee index|}}
+                {{hb-avatar-tooltip user=assignee width="24" height="24" multi=true index=index }}
+              {{/each}}
+            </div>
+          {{else}}
+            {{#if issue.assignee }}
+              {{hb-avatar-tooltip user=issue.assignee width="24" height="24" }}
+            {{/if}}
+          {{/if}}
+        </div>
+      </div>
+    </div>
     <div class="hb-column-indicator">
       <div class="card-states">
         <img src="{{asset-path "check.png"}}" title="Issue is closed" class="hb-state-closed"/>

--- a/ember-app/app/templates/components/hb-milestone-card.hbs
+++ b/ember-app/app/templates/components/hb-milestone-card.hbs
@@ -12,7 +12,7 @@
         <div class="avatar-wrapper">
           {{#if issue.assignees}}
             <div class="visible-assignees">
-              {{#each visibleAssignees as |assignee index|}}
+              {{#each limitedAssignees as |assignee index|}}
                 {{hb-avatar-tooltip user=assignee width="24" height="24" multi=true index=index }}
               {{/each}}
             </div>
@@ -20,6 +20,9 @@
             {{#if issue.assignee }}
               {{hb-avatar-tooltip user=issue.assignee width="24" height="24" }}
             {{/if}}
+          {{/if}}
+          {{#if assigneeOverflow}}
+            <div class='assignee-overflow'> +{{assigneeOverflow}} </div>
           {{/if}}
         </div>
       </div>

--- a/ember-app/app/templates/components/hb-milestone-card.hbs
+++ b/ember-app/app/templates/components/hb-milestone-card.hbs
@@ -10,6 +10,9 @@
     <div class="card-details-wrapper">
       <div class="card-details clearfix">
         <div class="avatar-wrapper">
+          {{#if assigneeOverflow}}
+            <div class='assignee-overflow'> +{{assigneeOverflow}} </div>
+          {{/if}}
           {{#if issue.assignees}}
             <div class="visible-assignees">
               {{#each limitedAssignees as |assignee index|}}
@@ -20,9 +23,6 @@
             {{#if issue.assignee }}
               {{hb-avatar-tooltip user=issue.assignee width="24" height="24" }}
             {{/if}}
-          {{/if}}
-          {{#if assigneeOverflow}}
-            <div class='assignee-overflow'> +{{assigneeOverflow}} </div>
           {{/if}}
         </div>
       </div>


### PR DESCRIPTION
Merges into https://github.com/huboard/huboard-web/pull/327

- Enables Multiple assignees on milestone cards (Max 3)
- Compacts the card
- Fixes bug where column meter would report the incorrect column on closed issues
- Moves the progress for columns proportionally (provides a more consistent experience across varying column counts)
- Sets the progress of all progress meter columns to empty until issue state as moved to column index 1, as such the number of progress columns has been reduced to 4 which provides the best possible experience for boards with 5 columns 

<!---
@huboard:{"order":261.104415661044,"milestone_order":339,"custom_state":""}
-->
