### PR TITLE
[WIP] Include the url referrer in server-side page jobs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -48,6 +48,7 @@ class ApplicationController < ActionController::Base
     job_params['current_user'] = (current_user.attribs || {}).to_h
     job_params['action_controller.params'] = params
     job_params['session_id'] = session['guid']
+    job_params['referrer'] = request.referrer
 
     #TODO: make sure you can safely serialize the params
     JobResolver.find_jobs(params).each do |job|

--- a/vendor/engines/saas/app/jobs/analytics/page_job.rb
+++ b/vendor/engines/saas/app/jobs/analytics/page_job.rb
@@ -8,7 +8,8 @@ module Analytics
         user_id: user,
         anonymous_id: params['session_id'],
         name: params['url'],
-        properties: { url: params['url'] }
+        properties: { url: params['url'] },
+        referrer: params['referrer']
       }
     end
   end

--- a/vendor/engines/saas/app/jobs/analytics/page_job.rb
+++ b/vendor/engines/saas/app/jobs/analytics/page_job.rb
@@ -8,8 +8,7 @@ module Analytics
         user_id: user,
         anonymous_id: params['session_id'],
         name: params['url'],
-        properties: { url: params['url'] },
-        referrer: params['referrer']
+        properties: { url: params['url'], referrer: params['referrer'] }
       }
     end
   end

--- a/vendor/engines/saas/app/jobs/base_login_job.rb
+++ b/vendor/engines/saas/app/jobs/base_login_job.rb
@@ -10,6 +10,7 @@ class BaseLoginJob < ActiveJob::Base
     Analytics::IdentifyUserJob.perform_later(user)
 
     user['url'] = "/login/#{params['action_controller.params']['action']}/authorized"
+    user['referrer'] = params['referrer']
     Analytics::PageJob.perform_later(user)
 
     req = couch.users.get(user['data']['id'])


### PR DESCRIPTION
I suspect our goal tracking is incomplete because server side `page()` calls for analytics don't include referral urls. 

Fixes #313