### PR TITLE
Hides create issue card from anonymous users

### DIFF
--- a/ember-app/app/components/columns/hb-column.js
+++ b/ember-app/app/components/columns/hb-column.js
@@ -37,7 +37,9 @@ var HbColumnComponent = Ember.Component.extend(SortableMixin, {
       return value;
     }
   }).property(),
-  isCreateVisible: Ember.computed.alias("model.isFirstColumn"),
+  isCreateVisible: function(){
+    return this.get('model.isFirstColumn') && App.get('loggedIn');
+  }.property("model.isFirstColumn"),
   topOrderNumber: function(){
     var issues = this.get("sortedIssues");
     var milestone_issues = this.get("issues").sort(function(a,b){

--- a/ember-app/app/components/columns/hb-milestone.js
+++ b/ember-app/app/components/columns/hb-milestone.js
@@ -69,7 +69,7 @@ var HbMilestoneComponent = HbColumn.extend(
       }
     });
   },
-  isCreateVisible: true,
+  isCreateVisible: App.get('loggedIn'),
   topOrderNumber: function(){
     var issues = this.get("issues")
       .filter(function(i) { return !i.get("isArchived");})


### PR DESCRIPTION
Previously, anonymous users would be allowed to attempt issue creation but fail ultimately. 

fixes #180 

<!---
@huboard:{"order":261.11094522958814,"milestone_order":351,"custom_state":""}
-->
