### PR TITLE
Fixes infinite loop create board loop

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -15,6 +15,7 @@
 @import "breadcrumbs";
 @import "account";
 @import "sidebar";
+@import "board/create";
 
 form {
   margin: 0;

--- a/app/assets/stylesheets/board/create.scss
+++ b/app/assets/stylesheets/board/create.scss
@@ -1,0 +1,52 @@
+.create-new-board--container {
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.create-new-board--message {
+  margin: 0px auto 30px auto;
+  margin-bottom: 30px;
+  font-size: 15px;
+}
+
+.create-new-board--list {
+  list-style: none;
+  padding-left: 10px;
+  padding-bottom: 10px;
+  text-align: left;
+  li {
+    border-left-style: solid;
+    border-left-color: $lightGrey;
+    padding-left: 10px;
+    margin-bottom: 14px;
+  }
+}
+
+.create-new-board--form {
+  input.btn.primary {
+    background: none;
+    font-size: 16px;
+    border-style: solid;
+    padding: 18px;
+    border-radius: 6px;
+    text-shadow: none;
+    &:hover {
+      background-color: $hb-purple;
+      color: white;
+    }
+  }
+}
+
+.create-new-board--labels {
+  @include display(flex);
+  @include align-items(center);
+  @include justify-content(center);
+  .labels-create-message {
+    font-size: 16px;
+    margin-bottom: 20px;
+  }
+  .labels-create-columns {
+    font-size: 14px;
+  }
+}

--- a/app/controllers/board_controller.rb
+++ b/app/controllers/board_controller.rb
@@ -23,7 +23,7 @@ class BoardController < ApplicationController
 
     def create_board
       return not_found unless logged_in?
-      @parameters = params
+      @parameters = params || []
       @repo = gh.repos(params[:user],params[:repo])
 
       board = huboard.board(params[:user], params[:repo])
@@ -34,11 +34,13 @@ class BoardController < ApplicationController
 
     def create
       begin
-        huboard.board(params[:user], params[:repo]).create_board
-        @event = 'board_created'
+        board = huboard.board(params[:user], params[:repo])
+        board.create_board
       rescue Ghee::UnprocessableEntity
         redirect_to "/#{params[:user]}/#{params[:repo]}/"
       end
+
+      return redirect_to action: 'create_board', create_failed: true unless board.has_board?
       redirect_to "/#{params[:user]}/#{params[:repo]}/"
     end
   end

--- a/app/views/board/create_board.html.erb
+++ b/app/views/board/create_board.html.erb
@@ -1,21 +1,66 @@
-<div class="instructions drop-shadow">
-  <h2> We noticed your repository issue tracker is not yet configured for HuBoard</h2>
-  <% if @repo && @repo['permissions'] && @repo['permissions']['push'] %>
-  <p> No worries, HuBoard can automatically get you started with a default label configuration </p>
-  <p> HuBoard will create the following labels </p>
-  <ol start="0">
-    <li> Backlog </li>
-    <li> Ready </li>
-    <li> Working </li>
-    <li> Review </li>
-    <li> Done </li>
-  </ol>
-  <%= form_tag 'create' do %>
-    <input class="btn primary" type="submit" value="Yes, Do it for me!" data-analytics-path='/board/creating'/>
-    <a href="<%= @repo['html_url'] %>/issues" target="_blank" >No thanks, I want to do this manually</a>
-  <% end %>
+<div class="instructions drop-shadow create-new-board">
+  <div class="create-new-board--container">
+  <% if @parameters['create_failed']%>
+    <h2> Oops! </h2>
+    <div class="create-new-board--message">
+      <h3> HuBoard is unable to create a board for you! </h3>
+      <ul class="create-new-board--list">
+        <li>You will need write permissions on <%= @parameters['user'] %>/<%= @parameters['repo'] %></li>
+        <li>If <%= @parameters['user'] %> is a GitHub Organization: <a href=https://help.github.com/articles/disabling-third-party-application-restrictions-for-your-organization/" target="blank">ensure no access restrictions are present</a></li>
+        <li><a href="mailto:support@huboard.com">Talk to us!</a></li>
+      </ul>
+      <%= form_tag 'create', class: 'create-new-board--form' do %>
+        <input class="btn primary" type="submit" value="Try again!" data-analytics-path='/board/creating'/>
+        <a href="/dashboard">
+          <input class="btn primary" type="button" value="Go home">
+        </a>
+      </div>
+      <% end %>
+    </div>
+  <% elsif @repo && @repo['permissions'] && @repo['permissions']['push'] %>
+    <h2> <%= @parameters['user'] %>/<%= @parameters['repo'] %> is not yet configured for HuBoard</h2>
+  <div class="create-new-board--message">
+    <h4> We can automatically get you started with a default label configuration: </h4>
+    <br>
+    <div class="create-new-board--labels">
+      <div class="labels-create-message">
+        <p> Allow HuBoard to create the following labels? </p>
+      </div>
+      <div class="labels-create-columns">
+        <ul class="create-new-board--list">
+          <li> 0 - Backlog </li>
+          <li> 1 - Ready </li>
+          <li> 2 - Working </li>
+          <li> 3 - Review </li>
+          <li> 4 - Done </li>
+        </ul>
+      </div>
+    </div>
+    <%= form_tag 'create', class: 'create-new-board--form' do %>
+      <input class="btn primary" type="submit" value="Yes, Do it for me!" data-analytics-path='/board/creating'/>
+      <a href="<%= @repo['html_url'] %>/issues" target="_blank" >
+        <input class="btn primary" type="button" value="Create columns manually">
+      </a>
+    </div>
+    <% end %>
   <% else %>
-    <p> Unfortunately, HuBoard doesn't have permission to fix that for you.  </p>
-    <p> You'll need to head over to <a href="<%= @repo['html_url'] %>">GitHub</a> for that</p>
+    <h2> <%= @parameters['user'] %>/<%= @parameters['repo'] %> is not yet configured for HuBoard</h2>
+    <div class="create-new-board--message">
+      <ul class="create-new-board--list">
+        <li>You will need write permission on <%= @parameters['user'] %>/<%= @parameters['repo'] %></li>
+        <li>If <%= @parameters['user'] %> is a GitHub Organization: <a href=https://help.github.com/articles/disabling-third-party-application-restrictions-for-your-organization/" target="blank">ensure no access restrictions are present</a></li>
+        <li><a href="mailto:support@huboard.com">Talk to us!</a></li>
+      </ul>
+      <%= form_tag 'create_board', class: 'create-new-board--form' do %>
+        <a href="/<%= @parameters['user'] %>/<%= @parameters['repo'] %>">
+          <input class="btn primary" type="button" value="Try again">
+        </a>
+        <a href="/dashboard">
+          <input class="btn primary" type="button" value="Go home">
+        </a>
+      </div>
+      <% end %>
+    </div>
   <% end %>
+  </div>
 </div>


### PR DESCRIPTION
Fixes the infinite loop and closes #357 

Additionally, as the changes required some styling, applied a bit of a facelift to the board create process altogether:

When prompted to create a board (buttons light up on hover):
![image](https://cloud.githubusercontent.com/assets/1130665/17536574/282f6734-5e53-11e6-8e36-8e0c6f667281.png)

When third party access restrictions are present:
![image](https://cloud.githubusercontent.com/assets/1130665/17536617/73eb89b4-5e53-11e6-8992-cd80ccd71daa.png)

When push bit is missing:
![image](https://cloud.githubusercontent.com/assets/1130665/17536664/c3a60e52-5e53-11e6-99ac-4ec3692da3c2.png)


@rauhryan @dahlbyk What do you think? Improvement ?
