### PR TITLE
Ensures archived label states arent overwritten

### DIFF
--- a/ember-app/app/models/new/issue.js
+++ b/ember-app/app/models/new/issue.js
@@ -208,6 +208,9 @@ var Issue = Model.extend(IssueFiltersMixin, Messaging, CardSubscriptions, {
   }.property('data.other_labels.[]'),
   customState: Ember.computed("data._data.custom_state", "data.other_labels.[]", "stateLabelName", {
     get:function(){
+      //Prevents stateLabelName from overriding archived state
+      if(this.get("_data.custom_state") === "archived"){ return "archived" }
+
       var state = this.get("stateLabelName");
       if(state){ return state; }
       return this.get("_data.custom_state");


### PR DESCRIPTION
The label state changes introduced the possibility of a blocked/ready label from overriding the `isArchived` property via `customState`. 