### PR TITLE
Clicking on card number should never open card

### DIFF
--- a/ember-app/app/components/hb-task-card.js
+++ b/ember-app/app/components/hb-task-card.js
@@ -65,7 +65,7 @@ var HbCardComponent = Ember.Component.extend(
     }),
     isFiltered: Ember.computed.alias('issue.isFiltered'),
     click: function(ev){
-      if(this.get("isFiltered") === "filter-hidden" || Ember.$(ev.target).is("a.xnumber")){
+      if(this.get("isFiltered") === "filter-hidden" || Ember.$(ev.target).is("a.number")){
         return;
       }
       var reference = Ember.$(ev.target).parent(".hb-card-tray").find('.number').data('issue-id');


### PR DESCRIPTION
Fixes a regression from the redesign where moving a card across columns then clicking on the number would both launch a new window to the issue AND open the issue in HuBoard. 