### PR TITLE
Reports the most recent commit status on PR's

### DIFF
--- a/app/controllers/api/issues_controller.rb
+++ b/app/controllers/api/issues_controller.rb
@@ -160,7 +160,7 @@ module Api
 
     def status
       repo = gh.repos(params[:user], params[:repo])
-      sha = repo.pulls(params[:number]).commits.first['sha']
+      sha = repo.pulls(params[:number]).commits.last['sha']
 
       render json: repo.commits(sha).status
     end


### PR DESCRIPTION
Small logic tweak, the github API returns commit shas from oldest -> newest, which we were using to fetch statuses. Now using the most recent commit sha to fetch the status. 