### PR TITLE
Added fix for issue 703 to make checkmark only show on selected users

### DIFF
--- a/app/assets/stylesheets/components/_selector.scss
+++ b/app/assets/stylesheets/components/_selector.scss
@@ -5,7 +5,7 @@
 
 }
 .hb-selector-component {
-  
+
   margin-top: 12px;
   padding-top: 12px;
   border-top: 1px solid #ccc;
@@ -89,17 +89,11 @@
     overflow-y: auto;
     .hb-menu-item {
       padding: 6px 12px;
-
       &:hover {
         cursor: pointer;
         background: $hb-purple;
         color: #fff;
-        .ui-icon-checkmark {
-          opacity: 1;
-          color: #fff;
-        }
       }
-
     }
   }
 


### PR DESCRIPTION
I hesitate to say fix since I find it more of a UI preference, but I removed the on hover check mark for assigned users on cards since once deselected, it can be confusing since they still look selected until you hover off. I opened issue 703 at [the parent repo](github.com/huboard/huboard) for this. 

Part of my reasoning for this is that the purple hover color is also a great indicator of who you can select so adding the check mark on top of that seems unnecessary. That is why I removed it completely instead of just removing it upon deselect. (I also removed some white space since I'm that kinda guy...)

Before
![beforeissue703dev](https://cloud.githubusercontent.com/assets/1214565/22168266/78224ace-df39-11e6-8963-4720b54ed904.png)

After
![afterissue703](https://cloud.githubusercontent.com/assets/1214565/22168270/7efa8aa0-df39-11e6-97bb-bc17cac34eb6.png)

Hopefully this fits with the UI design/usability that you are aiming for.